### PR TITLE
feat: auto-manage baseline coverage artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A reusable composite GitHub Action that parses LCOV coverage files, reports cove
 
 ## Features
 
+- **Automatic baseline management**: Stores coverage on main-branch pushes, auto-retrieves it on PRs
 - **Summary-only mode**: Report overall and per-file coverage without enforcing any rules
 - **Overall ratchet check**: Ensure overall coverage does not decrease compared to a baseline
 - **New-file threshold**: Require new files to meet a minimum coverage percentage
@@ -13,32 +14,31 @@ A reusable composite GitHub Action that parses LCOV coverage files, reports cove
 
 ## Usage
 
-### Summary-only mode
+### Basic usage (recommended)
 
-Report coverage without enforcing any rules. Always passes.
+```yaml
+- name: Run tests with coverage
+  run: flutter test --coverage
+
+- name: Check coverage
+  uses: pento/lcov-coverage-check@main
+  with:
+    new-file-minimum-coverage: 80
+    path: 'lib/'
+    changed-file-no-decrease: true
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+- **On main push**: summary report + stores LCOV as `lcov-baseline` artifact
+- **On PR**: auto-retrieves baseline, auto-detects git refs, runs full comparison, posts PR comment, stores `lcov-coverage` artifact
+
+### Summary-only mode (no token)
+
+Report coverage without enforcing any rules or managing artifacts. Always passes.
 
 ```yaml
 - name: Coverage summary
-  uses: your-org/lcov-coverage-check@v1
-  with:
-    lcov-file: coverage/lcov.info
-```
-
-### Comparison mode with baseline
-
-Compare current coverage against a baseline and enforce thresholds.
-
-```yaml
-- name: Check coverage
-  uses: your-org/lcov-coverage-check@v1
-  with:
-    lcov-file: coverage/lcov.info
-    lcov-base: coverage/baseline.lcov.info
-    base-ref: ${{ github.event.pull_request.base.sha }}
-    head-ref: ${{ github.event.pull_request.head.sha }}
-    new-file-minimum-coverage: '80'
-    changed-file-no-decrease: 'true'
-    github-token: ${{ secrets.GITHUB_TOKEN }}
+  uses: pento/lcov-coverage-check@main
 ```
 
 ### Full workflow example
@@ -47,6 +47,8 @@ Compare current coverage against a baseline and enforce thresholds.
 name: Coverage
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -61,22 +63,12 @@ jobs:
       - name: Run tests with coverage
         run: flutter test --coverage
 
-      - name: Download baseline coverage
-        # Fetch baseline coverage from your main branch artifact, cache, etc.
-        run: |
-          # Example: download from artifacts
-          gh run download --name coverage-baseline --dir baseline/ || true
-
       - name: Check coverage
-        uses: your-org/lcov-coverage-check@v1
+        uses: pento/lcov-coverage-check@main
         with:
-          lcov-file: coverage/lcov.info
-          lcov-base: baseline/lcov.info
-          base-ref: ${{ github.event.pull_request.base.sha }}
-          head-ref: ${{ github.event.pull_request.head.sha }}
-          new-file-minimum-coverage: '80'
-          new-file-path-prefix: 'lib/'
-          changed-file-no-decrease: 'true'
+          new-file-minimum-coverage: 80
+          path: 'lib/'
+          changed-file-no-decrease: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -84,14 +76,11 @@ jobs:
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `lcov-file` | **yes** | — | Path to current LCOV coverage file |
-| `lcov-base` | no | `''` | Path to baseline LCOV file. If empty, runs in summary-only mode |
-| `base-ref` | no | `''` | Git ref for base branch (for detecting new/changed files via `git diff`) |
-| `head-ref` | no | `HEAD` | Git ref for PR head |
+| `lcov-file` | no | `coverage/lcov.info` | Path to current LCOV coverage file |
 | `new-file-minimum-coverage` | no | `80` | Minimum coverage percentage for new files (0-100) |
-| `new-file-path-prefix` | no | `lib/` | Only enforce new-file threshold under this prefix. Empty = all paths |
+| `path` | no | `lib/` | Only enforce file-level checks under this path prefix. Empty = all paths |
 | `changed-file-no-decrease` | no | `true` | Require that per-file coverage of modified files does not decrease vs baseline |
-| `github-token` | no | `''` | GitHub token for posting PR summary comment. If empty, no comment is posted |
+| `github-token` | no | `''` | GitHub token for PR comments and artifact management. If empty, runs in summary-only mode |
 
 ## Outputs
 
@@ -100,20 +89,41 @@ jobs:
 | `overall-coverage` | Current overall coverage percentage (e.g., `87.50`) |
 | `baseline-coverage` | Baseline coverage percentage (empty if summary-only) |
 | `passed` | `'true'` or `'false'` |
+| `baseline-artifact-downloaded` | `'true'` if baseline was auto-retrieved from a previous run |
+
+## Automatic Baseline Management
+
+When `github-token` is provided, the action automatically manages baseline coverage artifacts:
+
+1. **On pushes to the default branch** (e.g., `main`): the current LCOV file is uploaded as an `lcov-baseline` artifact, overwriting any previous baseline.
+2. **On pull requests**: the action retrieves the `lcov-baseline` artifact from the latest successful default-branch run of the same workflow. It also extracts `base.sha` and `head.sha` from the PR event payload for `git diff` operations.
+3. **On pull requests**: the current LCOV file is also uploaded as an `lcov-coverage` artifact.
+
+If no baseline artifact is found (e.g., first run), the action falls back to summary-only mode gracefully.
+
+### Token permissions
+
+The `github-token` needs the following permissions:
+- `actions: read` — to list workflow runs and download artifacts
+- `pull-requests: write` — to post/update PR comments
+
+### Artifact retention
+
+Baseline artifacts follow your repository's default artifact retention policy. You can configure this in your repository settings or workflow file.
 
 ## How it works
 
-### Summary-only mode (no `lcov-base`)
+### Summary-only mode (no `github-token` or no baseline available)
 
 - Parses the LCOV file and prints overall + per-file coverage
 - Writes a markdown summary to `$GITHUB_STEP_SUMMARY`
 - Always exits 0 and sets `passed` to `true`
 
-### Comparison mode (with `lcov-base`)
+### Comparison mode (baseline auto-retrieved)
 
 1. **Overall ratchet**: Current overall coverage must be >= baseline overall coverage
-2. **New-file check**: If `base-ref` is set, new `.dart` files (detected via `git diff --diff-filter=A`) must meet the `new-file-minimum-coverage` threshold. Files with no instrumentable lines (`LF:0`) pass automatically. Files not found in the LCOV data are treated as 0% coverage.
-3. **Changed-file ratchet**: If `changed-file-no-decrease` is `true` and `base-ref` is set, modified `.dart` files must not have decreased per-file coverage. Files not present in the baseline LCOV data are skipped.
+2. **New-file check**: New `.dart` files (detected via `git diff --diff-filter=A`) must meet the `new-file-minimum-coverage` threshold. Files with no instrumentable lines (`LF:0`) pass automatically. Files not found in the LCOV data are treated as 0% coverage.
+3. **Changed-file ratchet**: If `changed-file-no-decrease` is `true`, modified `.dart` files must not have decreased per-file coverage. Files not present in the baseline LCOV data are skipped.
 
 ### PR comments
 
@@ -122,6 +132,9 @@ When `github-token` is provided and the action runs in a pull request context, a
 ## Edge cases
 
 - **Empty or missing LCOV files**: Treated as 0% coverage (not an error)
+- **First run (no baseline)**: Runs in summary-only mode. Baseline stored for next PR.
+- **Expired artifact**: Filtered by `expired == false`. Graceful fallback to summary-only.
+- **Fork PRs**: Token may lack `actions: read`. ERR trap handles graceful fallback.
 - **New file not in LCOV data**: Treated as 0% coverage, fails if below threshold
 - **New file with `LF:0`**: No instrumentable lines, passes automatically
 - **Modified file not in baseline LCOV**: Skipped (new to coverage tracking)
@@ -137,7 +150,7 @@ INPUT_LCOV_BASE=baseline/lcov.info \
 INPUT_BASE_REF=main \
 INPUT_HEAD_REF=HEAD \
 INPUT_NEW_FILE_MINIMUM_COVERAGE=80 \
-INPUT_NEW_FILE_PATH_PREFIX=lib/ \
+INPUT_PATH=lib/ \
 INPUT_CHANGED_FILE_NO_DECREASE=true \
 INPUT_GITHUB_TOKEN="" \
   ./scripts/check-coverage.sh

--- a/action.yml
+++ b/action.yml
@@ -5,25 +5,14 @@ author: 'Gary Pendergast'
 inputs:
   lcov-file:
     description: 'Path to current LCOV coverage file'
-    required: true
-  lcov-base:
-    description: 'Path to baseline LCOV file. If empty, runs in summary-only mode (report, do not enforce)'
     required: false
-    default: ''
-  base-ref:
-    description: 'Git ref for base branch (for detecting new/changed files via git diff)'
-    required: false
-    default: ''
-  head-ref:
-    description: 'Git ref for PR head'
-    required: false
-    default: 'HEAD'
+    default: 'coverage/lcov.info'
   new-file-minimum-coverage:
     description: 'Minimum coverage percentage for new files (0-100)'
     required: false
     default: '80'
-  new-file-path-prefix:
-    description: 'Only enforce new-file threshold under this prefix. Empty = all paths.'
+  path:
+    description: 'Only enforce file-level checks under this path prefix. Empty = all paths.'
     required: false
     default: 'lib/'
   changed-file-no-decrease:
@@ -31,7 +20,7 @@ inputs:
     required: false
     default: 'true'
   github-token:
-    description: 'GitHub token for posting PR summary comment. If empty, no comment is posted.'
+    description: 'GitHub token for PR comments and artifact management. If empty, no comments or artifacts.'
     required: false
     default: ''
 
@@ -45,6 +34,9 @@ outputs:
   passed:
     description: "'true' or 'false'"
     value: ${{ steps.coverage.outputs.passed }}
+  baseline-artifact-downloaded:
+    description: "'true' if baseline was auto-retrieved from a previous run"
+    value: ${{ steps.retrieve-baseline.outputs.downloaded }}
 
 branding:
   icon: 'shield'
@@ -53,16 +45,40 @@ branding:
 runs:
   using: composite
   steps:
+    - name: Retrieve baseline artifact
+      id: retrieve-baseline
+      if: inputs.github-token != ''
+      shell: bash
+      env:
+        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: "${{ github.action_path }}/scripts/retrieve-baseline.sh"
+
     - name: Check coverage
       id: coverage
       shell: bash
       env:
         INPUT_LCOV_FILE: ${{ inputs.lcov-file }}
-        INPUT_LCOV_BASE: ${{ inputs.lcov-base }}
-        INPUT_BASE_REF: ${{ inputs.base-ref }}
-        INPUT_HEAD_REF: ${{ inputs.head-ref }}
+        INPUT_LCOV_BASE: ${{ steps.retrieve-baseline.outputs.baseline-path }}
+        INPUT_BASE_REF: ${{ steps.retrieve-baseline.outputs.base-ref }}
+        INPUT_HEAD_REF: ${{ steps.retrieve-baseline.outputs.head-ref || 'HEAD' }}
         INPUT_NEW_FILE_MINIMUM_COVERAGE: ${{ inputs.new-file-minimum-coverage }}
-        INPUT_NEW_FILE_PATH_PREFIX: ${{ inputs.new-file-path-prefix }}
+        INPUT_PATH: ${{ inputs.path }}
         INPUT_CHANGED_FILE_NO_DECREASE: ${{ inputs.changed-file-no-decrease }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
       run: "${{ github.action_path }}/scripts/check-coverage.sh"
+
+    - name: Store baseline artifact
+      if: ${{ !cancelled() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: lcov-baseline
+        path: ${{ inputs.lcov-file }}
+        overwrite: true
+
+    - name: Store PR coverage artifact
+      if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: lcov-coverage
+        path: ${{ inputs.lcov-file }}
+        overwrite: true

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 #   INPUT_BASE_REF                  - Git ref for base branch (optional)
 #   INPUT_HEAD_REF                  - Git ref for PR head (default: HEAD)
 #   INPUT_NEW_FILE_MINIMUM_COVERAGE - Min coverage % for new files (default: 80)
-#   INPUT_NEW_FILE_PATH_PREFIX      - Only enforce under this prefix (default: lib/)
+#   INPUT_PATH                      - Only enforce under this prefix (default: lib/)
 #   INPUT_CHANGED_FILE_NO_DECREASE  - Require no per-file decrease (default: true)
 #   INPUT_GITHUB_TOKEN              - Token for PR comments (optional)
 #
@@ -32,7 +32,7 @@ INPUT_LCOV_BASE="${INPUT_LCOV_BASE:-}"
 INPUT_BASE_REF="${INPUT_BASE_REF:-}"
 INPUT_HEAD_REF="${INPUT_HEAD_REF:-HEAD}"
 INPUT_NEW_FILE_MINIMUM_COVERAGE="${INPUT_NEW_FILE_MINIMUM_COVERAGE:-80}"
-INPUT_NEW_FILE_PATH_PREFIX="${INPUT_NEW_FILE_PATH_PREFIX:-lib/}"
+INPUT_PATH="${INPUT_PATH:-lib/}"
 INPUT_CHANGED_FILE_NO_DECREASE="${INPUT_CHANGED_FILE_NO_DECREASE:-true}"
 INPUT_GITHUB_TOKEN="${INPUT_GITHUB_TOKEN:-}"
 
@@ -215,16 +215,7 @@ if [[ -n "$INPUT_BASE_REF" ]]; then
   echo ""
   echo "-- New File Coverage Check (minimum: ${INPUT_NEW_FILE_MINIMUM_COVERAGE}%) --"
 
-  base_ref="$INPUT_BASE_REF"
-  head_ref="$INPUT_HEAD_REF"
-  prefix="$INPUT_NEW_FILE_PATH_PREFIX"
-
-  # Build the git diff command for new files
-  if [[ -n "$prefix" ]]; then
-    new_files="$(git diff --name-only --diff-filter=A "${base_ref}...${head_ref}" -- "${prefix}*.dart" 2>/dev/null || true)"
-  else
-    new_files="$(git diff --name-only --diff-filter=A "${base_ref}...${head_ref}" -- '*.dart' 2>/dev/null || true)"
-  fi
+  new_files="$(git diff --name-only --diff-filter=A "${INPUT_BASE_REF}...${INPUT_HEAD_REF}" -- "${INPUT_PATH}*.dart" 2>/dev/null || true)"
 
   if [[ -z "$new_files" ]]; then
     echo "  No new files detected."
@@ -282,15 +273,7 @@ if [[ "$INPUT_CHANGED_FILE_NO_DECREASE" == "true" && -n "$INPUT_BASE_REF" ]]; th
   echo ""
   echo "-- Changed File Ratchet Check --"
 
-  base_ref="$INPUT_BASE_REF"
-  head_ref="$INPUT_HEAD_REF"
-  prefix="$INPUT_NEW_FILE_PATH_PREFIX"
-
-  if [[ -n "$prefix" ]]; then
-    modified_files="$(git diff --name-only --diff-filter=M "${base_ref}...${head_ref}" -- "${prefix}*.dart" 2>/dev/null || true)"
-  else
-    modified_files="$(git diff --name-only --diff-filter=M "${base_ref}...${head_ref}" -- '*.dart' 2>/dev/null || true)"
-  fi
+  modified_files="$(git diff --name-only --diff-filter=M "${INPUT_BASE_REF}...${INPUT_HEAD_REF}" -- "${INPUT_PATH}*.dart" 2>/dev/null || true)"
 
   if [[ -z "$modified_files" ]]; then
     echo "  No modified files detected."
@@ -409,7 +392,7 @@ if [[ -n "$INPUT_GITHUB_TOKEN" && -n "${GITHUB_REPOSITORY:-}" && -n "$pr_number"
   existing_comment_id="$(
     curl -s -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
       -H "Accept: application/vnd.github+json" \
-      "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments?per_page=100" \
+      "${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments?per_page=100" \
     | jq -r ".[] | select(.body | startswith(\"${comment_marker}\")) | .id" \
     | head -1 || true
   )"
@@ -419,7 +402,7 @@ if [[ -n "$INPUT_GITHUB_TOKEN" && -n "${GITHUB_REPOSITORY:-}" && -n "$pr_number"
     curl -s -X PATCH \
       -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
       -H "Accept: application/vnd.github+json" \
-      "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/comments/${existing_comment_id}" \
+      "${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/issues/comments/${existing_comment_id}" \
       -d "{\"body\": ${comment_body_json}}" > /dev/null
     echo "  Updated existing PR comment (ID: ${existing_comment_id})"
   else
@@ -427,7 +410,7 @@ if [[ -n "$INPUT_GITHUB_TOKEN" && -n "${GITHUB_REPOSITORY:-}" && -n "$pr_number"
     curl -s -X POST \
       -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
       -H "Accept: application/vnd.github+json" \
-      "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
+      "${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
       -d "{\"body\": ${comment_body_json}}" > /dev/null
     echo "  Created new PR comment"
   fi

--- a/scripts/retrieve-baseline.sh
+++ b/scripts/retrieve-baseline.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+###############################################################################
+# retrieve-baseline.sh
+#
+# Retrieves the baseline LCOV artifact from the latest successful
+# default-branch run of the same workflow. Also auto-detects git refs
+# from the PR event payload.
+#
+# Environment variables (inputs):
+#   INPUT_GITHUB_TOKEN  - GitHub token for API access (required)
+#
+# GitHub Actions environment:
+#   GITHUB_OUTPUT       - File to write outputs
+#   GITHUB_REPOSITORY   - owner/repo
+#   GITHUB_RUN_ID       - Current workflow run ID
+#   GITHUB_API_URL      - API base URL (defaults to https://api.github.com)
+#   GITHUB_EVENT_PATH   - Path to event payload JSON
+#
+# Outputs (via $GITHUB_OUTPUT):
+#   downloaded    - "true" if baseline was successfully retrieved
+#   baseline-path - path to the downloaded baseline LCOV file
+#   base-ref      - base SHA from PR event payload
+#   head-ref      - head SHA from PR event payload
+###############################################################################
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+write_output() {
+  local key="$1" value="$2"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "${key}=${value}" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+# On any error, gracefully fall back to summary-only mode
+trap 'echo "::notice::Baseline artifact retrieval failed — running in summary-only mode"; write_output "downloaded" "false"; exit 0' ERR
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+API_BASE="${GITHUB_API_URL:-https://api.github.com}"
+AUTH_HEADER="Authorization: token ${INPUT_GITHUB_TOKEN}"
+ACCEPT_HEADER="Accept: application/vnd.github+json"
+
+# ---------------------------------------------------------------------------
+# 1. Get workflow ID from current run
+# ---------------------------------------------------------------------------
+workflow_id="$(curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
+  "${API_BASE}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+  | jq -r '.workflow_id')"
+
+if [[ -z "$workflow_id" || "$workflow_id" == "null" ]]; then
+  echo "::notice::Could not determine workflow ID — running in summary-only mode"
+  write_output "downloaded" "false"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Get default branch
+# ---------------------------------------------------------------------------
+default_branch="$(curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
+  "${API_BASE}/repos/${GITHUB_REPOSITORY}" \
+  | jq -r '.default_branch')"
+
+if [[ -z "$default_branch" || "$default_branch" == "null" ]]; then
+  echo "::notice::Could not determine default branch — running in summary-only mode"
+  write_output "downloaded" "false"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Find latest successful run on default branch
+# ---------------------------------------------------------------------------
+run_id="$(curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
+  "${API_BASE}/repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_id}/runs?branch=${default_branch}&status=success&per_page=1" \
+  | jq -r '.workflow_runs[0].id // empty')"
+
+if [[ -z "$run_id" ]]; then
+  echo "::notice::No successful runs found on ${default_branch} — running in summary-only mode"
+  write_output "downloaded" "false"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Find lcov-baseline artifact (not expired)
+# ---------------------------------------------------------------------------
+artifact_url="$(curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
+  "${API_BASE}/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts" \
+  | jq -r '.artifacts[] | select(.name == "lcov-baseline" and .expired == false) | .archive_download_url' \
+  | head -1)"
+
+if [[ -z "$artifact_url" ]]; then
+  echo "::notice::No lcov-baseline artifact found in run ${run_id} — running in summary-only mode"
+  write_output "downloaded" "false"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Download and extract artifact
+# ---------------------------------------------------------------------------
+tmpdir="$(mktemp -d)"
+curl -s -L -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
+  -o "${tmpdir}/artifact.zip" "$artifact_url"
+
+unzip -q -o "${tmpdir}/artifact.zip" -d "${tmpdir}/artifact"
+
+# Find the .info or .lcov file
+baseline_file="$(find "${tmpdir}/artifact" -type f \( -name '*.info' -o -name '*.lcov' \) | head -1)"
+
+if [[ -z "$baseline_file" ]]; then
+  echo "::notice::No .info or .lcov file found in baseline artifact — running in summary-only mode"
+  write_output "downloaded" "false"
+  exit 0
+fi
+
+echo "Baseline artifact downloaded from run ${run_id}"
+write_output "downloaded" "true"
+write_output "baseline-path" "$baseline_file"
+
+# ---------------------------------------------------------------------------
+# 6. Extract git refs from PR event payload
+# ---------------------------------------------------------------------------
+if [[ -n "${GITHUB_EVENT_PATH:-}" && -f "${GITHUB_EVENT_PATH:-}" ]]; then
+  base_sha="$(jq -r '.pull_request.base.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"
+  head_sha="$(jq -r '.pull_request.head.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"
+
+  if [[ -n "$base_sha" ]]; then
+    write_output "base-ref" "$base_sha"
+  fi
+  if [[ -n "$head_sha" ]]; then
+    write_output "head-ref" "$head_sha"
+  fi
+fi

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 CHECK_SCRIPT="$PROJECT_DIR/scripts/check-coverage.sh"
+RETRIEVE_SCRIPT="$PROJECT_DIR/scripts/retrieve-baseline.sh"
 FIXTURES_DIR="$SCRIPT_DIR/fixtures"
 
 TESTS_RUN=0
@@ -122,7 +123,7 @@ output="$(
   INPUT_BASE_REF="" \
   INPUT_HEAD_REF="HEAD" \
   INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_NEW_FILE_PATH_PREFIX="lib/" \
+  INPUT_PATH="lib/" \
   INPUT_CHANGED_FILE_NO_DECREASE="true" \
   INPUT_GITHUB_TOKEN="" \
   bash "$CHECK_SCRIPT" 2>&1
@@ -163,7 +164,7 @@ output="$(
   INPUT_BASE_REF="" \
   INPUT_HEAD_REF="HEAD" \
   INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_NEW_FILE_PATH_PREFIX="lib/" \
+  INPUT_PATH="lib/" \
   INPUT_CHANGED_FILE_NO_DECREASE="true" \
   INPUT_GITHUB_TOKEN="" \
   bash "$CHECK_SCRIPT" 2>&1
@@ -192,7 +193,7 @@ output="$(
   INPUT_BASE_REF="" \
   INPUT_HEAD_REF="HEAD" \
   INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_NEW_FILE_PATH_PREFIX="lib/" \
+  INPUT_PATH="lib/" \
   INPUT_CHANGED_FILE_NO_DECREASE="true" \
   INPUT_GITHUB_TOKEN="" \
   bash "$CHECK_SCRIPT" 2>&1
@@ -235,7 +236,7 @@ output="$(
   INPUT_BASE_REF="base_ref" \
   INPUT_HEAD_REF="head_ref" \
   INPUT_NEW_FILE_MINIMUM_COVERAGE="40" \
-  INPUT_NEW_FILE_PATH_PREFIX="lib/" \
+  INPUT_PATH="lib/" \
   INPUT_CHANGED_FILE_NO_DECREASE="false" \
   INPUT_GITHUB_TOKEN="" \
   bash "$CHECK_SCRIPT" 2>&1
@@ -273,7 +274,7 @@ output="$(
   INPUT_BASE_REF="base_ref" \
   INPUT_HEAD_REF="head_ref" \
   INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_NEW_FILE_PATH_PREFIX="lib/" \
+  INPUT_PATH="lib/" \
   INPUT_CHANGED_FILE_NO_DECREASE="false" \
   INPUT_GITHUB_TOKEN="" \
   bash "$CHECK_SCRIPT" 2>&1
@@ -308,7 +309,7 @@ output="$(
   INPUT_BASE_REF="" \
   INPUT_HEAD_REF="HEAD" \
   INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_NEW_FILE_PATH_PREFIX="lib/" \
+  INPUT_PATH="lib/" \
   INPUT_CHANGED_FILE_NO_DECREASE="true" \
   INPUT_GITHUB_TOKEN="" \
   bash "$CHECK_SCRIPT" 2>&1
@@ -353,7 +354,7 @@ output="$(
   INPUT_BASE_REF="base_ref" \
   INPUT_HEAD_REF="head_ref" \
   INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_NEW_FILE_PATH_PREFIX="lib/" \
+  INPUT_PATH="lib/" \
   INPUT_CHANGED_FILE_NO_DECREASE="false" \
   INPUT_GITHUB_TOKEN="" \
   bash "$CHECK_SCRIPT" 2>&1
@@ -393,7 +394,7 @@ output="$(
   INPUT_BASE_REF="base_ref" \
   INPUT_HEAD_REF="head_ref" \
   INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_NEW_FILE_PATH_PREFIX="lib/" \
+  INPUT_PATH="lib/" \
   INPUT_CHANGED_FILE_NO_DECREASE="true" \
   INPUT_GITHUB_TOKEN="" \
   bash "$CHECK_SCRIPT" 2>&1
@@ -432,7 +433,7 @@ output="$(
   INPUT_BASE_REF="base_ref" \
   INPUT_HEAD_REF="head_ref" \
   INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_NEW_FILE_PATH_PREFIX="lib/" \
+  INPUT_PATH="lib/" \
   INPUT_CHANGED_FILE_NO_DECREASE="true" \
   INPUT_GITHUB_TOKEN="" \
   bash "$CHECK_SCRIPT" 2>&1
@@ -478,7 +479,7 @@ output="$(
   INPUT_BASE_REF="base_ref" \
   INPUT_HEAD_REF="head_ref" \
   INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_NEW_FILE_PATH_PREFIX="lib/" \
+  INPUT_PATH="lib/" \
   INPUT_CHANGED_FILE_NO_DECREASE="true" \
   INPUT_GITHUB_TOKEN="" \
   bash "$CHECK_SCRIPT" 2>&1
@@ -533,7 +534,7 @@ output="$(
   INPUT_BASE_REF="" \
   INPUT_HEAD_REF="HEAD" \
   INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_NEW_FILE_PATH_PREFIX="lib/" \
+  INPUT_PATH="lib/" \
   INPUT_CHANGED_FILE_NO_DECREASE="true" \
   INPUT_GITHUB_TOKEN="fake-token" \
   bash "$CHECK_SCRIPT" 2>&1
@@ -580,7 +581,7 @@ output="$(
   INPUT_BASE_REF="" \
   INPUT_HEAD_REF="HEAD" \
   INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_NEW_FILE_PATH_PREFIX="lib/" \
+  INPUT_PATH="lib/" \
   INPUT_CHANGED_FILE_NO_DECREASE="true" \
   INPUT_GITHUB_TOKEN="fake-token" \
   bash "$CHECK_SCRIPT" 2>&1
@@ -614,7 +615,7 @@ output="$(
   INPUT_BASE_REF="" \
   INPUT_HEAD_REF="HEAD" \
   INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_NEW_FILE_PATH_PREFIX="lib/" \
+  INPUT_PATH="lib/" \
   INPUT_CHANGED_FILE_NO_DECREASE="true" \
   INPUT_GITHUB_TOKEN="fake-token" \
   bash "$CHECK_SCRIPT" 2>&1
@@ -666,7 +667,7 @@ output="$(
   INPUT_BASE_REF="" \
   INPUT_HEAD_REF="HEAD" \
   INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_NEW_FILE_PATH_PREFIX="lib/" \
+  INPUT_PATH="lib/" \
   INPUT_CHANGED_FILE_NO_DECREASE="true" \
   INPUT_GITHUB_TOKEN="fake-token" \
   bash "$CHECK_SCRIPT" 2>&1
@@ -689,6 +690,483 @@ if grep -q "\-X PATCH" "$curl_log" 2>/dev/null; then
   pass "curl used PATCH to update existing comment"
 else
   fail "curl should have used PATCH"
+fi
+
+rm -f "$event_payload"
+rm -rf "$mock_bin"
+
+# ---------------------------------------------------------------------------
+# Test 15: Baseline retrieval succeeds
+# ---------------------------------------------------------------------------
+run_test "Baseline retrieval: succeeds with valid API responses"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-test-XXXXXX")"
+
+# Create a baseline LCOV file and zip it
+mkdir -p "${tmpdir}/artifact-content"
+cp "$FIXTURES_DIR/baseline.lcov.info" "${tmpdir}/artifact-content/lcov.info"
+(cd "${tmpdir}/artifact-content" && zip -q "${tmpdir}/test-artifact.zip" lcov.info)
+
+# Create event payload with PR refs
+event_payload="${tmpdir}/event.json"
+cat > "$event_payload" <<'JSON'
+{"pull_request": {"base": {"sha": "abc123base"}, "head": {"sha": "def456head"}, "number": 42}}
+JSON
+
+# Create mock curl with counter-based dispatch
+mock_bin="${tmpdir}/mock-bin"
+mkdir -p "$mock_bin"
+cp "${tmpdir}/test-artifact.zip" "${mock_bin}/test-artifact.zip"
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+mock_dir="$(dirname "$0")"
+counter_file="${mock_dir}/curl_counter"
+if [[ ! -f "$counter_file" ]]; then echo 0 > "$counter_file"; fi
+count=$(cat "$counter_file")
+count=$((count + 1))
+echo "$count" > "$counter_file"
+
+# Parse -o argument for file download
+output_file=""
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  if [[ "${args[$i]}" == "-o" ]]; then
+    output_file="${args[$((i+1))]}"
+    break
+  fi
+done
+
+case $count in
+  1) echo '{"workflow_id": 12345}' ;;
+  2) echo '{"default_branch": "main"}' ;;
+  3) echo '{"workflow_runs": [{"id": 67890}]}' ;;
+  4) echo '{"artifacts": [{"name": "lcov-baseline", "expired": false, "archive_download_url": "https://example.com/artifact.zip"}]}' ;;
+  5) if [[ -n "$output_file" ]]; then cp "${mock_dir}/test-artifact.zip" "$output_file"; fi ;;
+esac
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
+# Set up GITHUB_OUTPUT
+github_output="${tmpdir}/github_output"
+: > "$github_output"
+
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_OUTPUT="$github_output" \
+  GITHUB_EVENT_PATH="$event_payload" \
+  GITHUB_REPOSITORY="owner/repo" \
+  GITHUB_RUN_ID="11111" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$RETRIEVE_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+if grep -q "downloaded=true" "$github_output"; then
+  pass "output contains downloaded=true"
+else
+  fail "output missing downloaded=true"
+fi
+
+if grep -q "baseline-path=" "$github_output"; then
+  baseline_path="$(grep "baseline-path=" "$github_output" | cut -d= -f2-)"
+  if [[ -f "$baseline_path" ]]; then
+    pass "baseline file exists at output path"
+  else
+    fail "baseline file does not exist at output path"
+  fi
+else
+  fail "output missing baseline-path"
+fi
+
+if grep -q "base-ref=abc123base" "$github_output"; then
+  pass "base-ref correctly detected from event payload"
+else
+  fail "base-ref not detected"
+fi
+
+if grep -q "head-ref=def456head" "$github_output"; then
+  pass "head-ref correctly detected from event payload"
+else
+  fail "head-ref not detected"
+fi
+
+rm -rf "$tmpdir"
+
+# ---------------------------------------------------------------------------
+# Test 16: Baseline retrieval — no successful runs
+# ---------------------------------------------------------------------------
+run_test "Baseline retrieval: no successful runs on default branch"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-test-XXXXXX")"
+
+mock_bin="${tmpdir}/mock-bin"
+mkdir -p "$mock_bin"
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+mock_dir="$(dirname "$0")"
+counter_file="${mock_dir}/curl_counter"
+if [[ ! -f "$counter_file" ]]; then echo 0 > "$counter_file"; fi
+count=$(cat "$counter_file")
+count=$((count + 1))
+echo "$count" > "$counter_file"
+
+case $count in
+  1) echo '{"workflow_id": 12345}' ;;
+  2) echo '{"default_branch": "main"}' ;;
+  3) echo '{"workflow_runs": []}' ;;
+esac
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
+github_output="${tmpdir}/github_output"
+: > "$github_output"
+
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_OUTPUT="$github_output" \
+  GITHUB_REPOSITORY="owner/repo" \
+  GITHUB_RUN_ID="11111" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$RETRIEVE_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0 (graceful fallback)"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+if grep -q "downloaded=false" "$github_output"; then
+  pass "output contains downloaded=false"
+else
+  fail "output missing downloaded=false"
+fi
+
+rm -rf "$tmpdir"
+
+# ---------------------------------------------------------------------------
+# Test 17: Baseline retrieval — artifact missing/expired
+# ---------------------------------------------------------------------------
+run_test "Baseline retrieval: artifact missing or expired"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-test-XXXXXX")"
+
+mock_bin="${tmpdir}/mock-bin"
+mkdir -p "$mock_bin"
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+mock_dir="$(dirname "$0")"
+counter_file="${mock_dir}/curl_counter"
+if [[ ! -f "$counter_file" ]]; then echo 0 > "$counter_file"; fi
+count=$(cat "$counter_file")
+count=$((count + 1))
+echo "$count" > "$counter_file"
+
+case $count in
+  1) echo '{"workflow_id": 12345}' ;;
+  2) echo '{"default_branch": "main"}' ;;
+  3) echo '{"workflow_runs": [{"id": 67890}]}' ;;
+  4) echo '{"artifacts": []}' ;;
+esac
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
+github_output="${tmpdir}/github_output"
+: > "$github_output"
+
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_OUTPUT="$github_output" \
+  GITHUB_REPOSITORY="owner/repo" \
+  GITHUB_RUN_ID="11111" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$RETRIEVE_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0 (graceful fallback)"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+if grep -q "downloaded=false" "$github_output"; then
+  pass "output contains downloaded=false"
+else
+  fail "output missing downloaded=false"
+fi
+
+rm -rf "$tmpdir"
+
+# ---------------------------------------------------------------------------
+# Test 18: Baseline retrieval — API error (curl failure)
+# ---------------------------------------------------------------------------
+run_test "Baseline retrieval: API error triggers graceful fallback"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-test-XXXXXX")"
+
+mock_bin="${tmpdir}/mock-bin"
+mkdir -p "$mock_bin"
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+exit 1
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
+github_output="${tmpdir}/github_output"
+: > "$github_output"
+
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_OUTPUT="$github_output" \
+  GITHUB_REPOSITORY="owner/repo" \
+  GITHUB_RUN_ID="11111" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$RETRIEVE_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0 (graceful fallback)"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+if grep -q "downloaded=false" "$github_output"; then
+  pass "output contains downloaded=false"
+else
+  fail "output missing downloaded=false"
+fi
+
+rm -rf "$tmpdir"
+
+# ---------------------------------------------------------------------------
+# Test 19: Baseline retrieval — auto-detects refs from PR event payload
+# ---------------------------------------------------------------------------
+run_test "Baseline retrieval: auto-detects refs from PR event payload"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-test-XXXXXX")"
+
+# Create a baseline LCOV file and zip it
+mkdir -p "${tmpdir}/artifact-content"
+cp "$FIXTURES_DIR/baseline.lcov.info" "${tmpdir}/artifact-content/lcov.info"
+(cd "${tmpdir}/artifact-content" && zip -q "${tmpdir}/test-artifact.zip" lcov.info)
+
+# Create event payload with specific SHAs
+event_payload="${tmpdir}/event.json"
+cat > "$event_payload" <<'JSON'
+{"pull_request": {"base": {"sha": "sha-base-1234"}, "head": {"sha": "sha-head-5678"}, "number": 99}}
+JSON
+
+mock_bin="${tmpdir}/mock-bin"
+mkdir -p "$mock_bin"
+cp "${tmpdir}/test-artifact.zip" "${mock_bin}/test-artifact.zip"
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+mock_dir="$(dirname "$0")"
+counter_file="${mock_dir}/curl_counter"
+if [[ ! -f "$counter_file" ]]; then echo 0 > "$counter_file"; fi
+count=$(cat "$counter_file")
+count=$((count + 1))
+echo "$count" > "$counter_file"
+
+output_file=""
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  if [[ "${args[$i]}" == "-o" ]]; then
+    output_file="${args[$((i+1))]}"
+    break
+  fi
+done
+
+case $count in
+  1) echo '{"workflow_id": 12345}' ;;
+  2) echo '{"default_branch": "main"}' ;;
+  3) echo '{"workflow_runs": [{"id": 67890}]}' ;;
+  4) echo '{"artifacts": [{"name": "lcov-baseline", "expired": false, "archive_download_url": "https://example.com/artifact.zip"}]}' ;;
+  5) if [[ -n "$output_file" ]]; then cp "${mock_dir}/test-artifact.zip" "$output_file"; fi ;;
+esac
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
+github_output="${tmpdir}/github_output"
+: > "$github_output"
+
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_OUTPUT="$github_output" \
+  GITHUB_EVENT_PATH="$event_payload" \
+  GITHUB_REPOSITORY="owner/repo" \
+  GITHUB_RUN_ID="11111" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$RETRIEVE_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+if grep -q "base-ref=sha-base-1234" "$github_output"; then
+  pass "base-ref detected as sha-base-1234"
+else
+  fail "base-ref not correctly detected"
+fi
+
+if grep -q "head-ref=sha-head-5678" "$github_output"; then
+  pass "head-ref detected as sha-head-5678"
+else
+  fail "head-ref not correctly detected"
+fi
+
+rm -rf "$tmpdir"
+
+# ---------------------------------------------------------------------------
+# Test 20: Baseline retrieval — does not detect refs on push event
+# ---------------------------------------------------------------------------
+run_test "Baseline retrieval: does not detect refs on push event"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-test-XXXXXX")"
+
+# Create a baseline LCOV file and zip it
+mkdir -p "${tmpdir}/artifact-content"
+cp "$FIXTURES_DIR/baseline.lcov.info" "${tmpdir}/artifact-content/lcov.info"
+(cd "${tmpdir}/artifact-content" && zip -q "${tmpdir}/test-artifact.zip" lcov.info)
+
+# Create a push event payload (no pull_request field)
+event_payload="${tmpdir}/event.json"
+cat > "$event_payload" <<'JSON'
+{"ref": "refs/heads/main", "after": "abc123"}
+JSON
+
+mock_bin="${tmpdir}/mock-bin"
+mkdir -p "$mock_bin"
+cp "${tmpdir}/test-artifact.zip" "${mock_bin}/test-artifact.zip"
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+mock_dir="$(dirname "$0")"
+counter_file="${mock_dir}/curl_counter"
+if [[ ! -f "$counter_file" ]]; then echo 0 > "$counter_file"; fi
+count=$(cat "$counter_file")
+count=$((count + 1))
+echo "$count" > "$counter_file"
+
+output_file=""
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  if [[ "${args[$i]}" == "-o" ]]; then
+    output_file="${args[$((i+1))]}"
+    break
+  fi
+done
+
+case $count in
+  1) echo '{"workflow_id": 12345}' ;;
+  2) echo '{"default_branch": "main"}' ;;
+  3) echo '{"workflow_runs": [{"id": 67890}]}' ;;
+  4) echo '{"artifacts": [{"name": "lcov-baseline", "expired": false, "archive_download_url": "https://example.com/artifact.zip"}]}' ;;
+  5) if [[ -n "$output_file" ]]; then cp "${mock_dir}/test-artifact.zip" "$output_file"; fi ;;
+esac
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
+github_output="${tmpdir}/github_output"
+: > "$github_output"
+
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_OUTPUT="$github_output" \
+  GITHUB_EVENT_PATH="$event_payload" \
+  GITHUB_REPOSITORY="owner/repo" \
+  GITHUB_RUN_ID="11111" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$RETRIEVE_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+if grep -q "downloaded=true" "$github_output"; then
+  pass "baseline still downloaded on push event"
+else
+  fail "baseline should still be downloaded"
+fi
+
+if ! grep -q "base-ref=" "$github_output"; then
+  pass "no base-ref detected (push event, no pull_request)"
+else
+  fail "base-ref should not be set for push events"
+fi
+
+if ! grep -q "head-ref=" "$github_output"; then
+  pass "no head-ref detected (push event, no pull_request)"
+else
+  fail "head-ref should not be set for push events"
+fi
+
+rm -rf "$tmpdir"
+
+# ---------------------------------------------------------------------------
+# Test 21: GHES compatibility — check-coverage.sh uses GITHUB_API_URL
+# ---------------------------------------------------------------------------
+run_test "GHES compatibility: check-coverage.sh uses GITHUB_API_URL"
+
+event_payload="$(mktemp "${TMPDIR:-/tmp}/event-payload-XXXXXX.json")"
+echo '{"pull_request": {"number": 42}}' > "$event_payload"
+
+# Create a mock curl that logs its calls
+mock_bin="$(mktemp -d "${TMPDIR:-/tmp}/mock-bin-XXXXXX")"
+curl_log="${mock_bin}/curl.log"
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+echo "$@" >> "$(dirname "$0")/curl.log"
+if echo "$@" | grep -q "\-X POST\|\-X PATCH"; then
+  echo '{}'
+else
+  echo '[]'
+fi
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_API_URL="https://github.example.com/api/v3" \
+  GITHUB_EVENT_PATH="$event_payload" \
+  GITHUB_REPOSITORY="owner/repo" \
+  INPUT_LCOV_FILE="$FIXTURES_DIR/current.lcov.info" \
+  INPUT_LCOV_BASE="$FIXTURES_DIR/baseline.lcov.info" \
+  INPUT_BASE_REF="" \
+  INPUT_HEAD_REF="HEAD" \
+  INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
+  INPUT_PATH="lib/" \
+  INPUT_CHANGED_FILE_NO_DECREASE="true" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$CHECK_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+if grep -q "github.example.com/api/v3" "$curl_log" 2>/dev/null; then
+  pass "curl used GITHUB_API_URL (GHES endpoint)"
+else
+  fail "curl did not use GITHUB_API_URL"
+fi
+
+if ! grep -q "api.github.com" "$curl_log" 2>/dev/null; then
+  pass "curl did not use default api.github.com"
+else
+  fail "curl should not use api.github.com when GITHUB_API_URL is set"
 fi
 
 rm -f "$event_payload"


### PR DESCRIPTION
## Summary

- Adds automatic baseline artifact management: on main pushes the LCOV file is stored as `lcov-baseline`, on PRs it's auto-retrieved and git refs are auto-detected from the event payload
- Simplifies user-facing inputs by removing `lcov-base`, `base-ref`, `head-ref`, and `new-file-path-prefix` — users just provide `github-token` and the action handles the rest
- Fixes GHES compatibility by using `GITHUB_API_URL` for all API calls instead of hardcoded `api.github.com`
- Renames `INPUT_NEW_FILE_PATH_PREFIX` → `INPUT_PATH` and simplifies git diff logic

## Test plan

- [x] All 14 existing tests pass with renamed env vars
- [x] 7 new tests added for baseline retrieval scenarios (success, no runs, missing artifact, API error, ref detection, push event, GHES compat)
- [x] Full test suite: 21 tests, 56 assertions, 0 failures
- [ ] Integration test: push to main → verify `lcov-baseline` artifact is stored
- [ ] Integration test: open PR → verify baseline is auto-retrieved and comparison works