### PR TITLE
fix: surface actionable error when github-token lacks actions:read

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ A reusable composite GitHub Action that parses LCOV coverage files, reports cove
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+> **Note**: When using `github-token`, your workflow needs `actions: read` permission. See [Token permissions](#token-permissions).
+
 - **On main push**: summary report + stores LCOV as `lcov-baseline` artifact
 - **On PR**: auto-retrieves baseline, auto-detects git refs, runs full comparison, posts PR comment, stores `lcov-coverage` artifact
 
@@ -56,6 +58,10 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/retrieve-baseline.sh
+++ b/scripts/retrieve-baseline.sh
@@ -49,9 +49,17 @@ ACCEPT_HEADER="Accept: application/vnd.github+json"
 # ---------------------------------------------------------------------------
 # 1. Get workflow ID from current run
 # ---------------------------------------------------------------------------
-workflow_id="$(curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
-  "${API_BASE}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-  | jq -r '.workflow_id')"
+response="$(curl -s -w '\n%{http_code}' -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
+  "${API_BASE}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}")"
+http_code="$(echo "$response" | tail -1)"
+body="$(echo "$response" | sed '$d')"
+workflow_id="$(echo "$body" | jq -r '.workflow_id')"
+
+if [[ "$http_code" == "403" || "$http_code" == "404" ]]; then
+  echo "::notice::GitHub API returned HTTP ${http_code} — the github-token likely needs 'actions: read' permission. Add 'permissions: actions: read' to your workflow. Running in summary-only mode."
+  write_output "downloaded" "false"
+  exit 0
+fi
 
 if [[ -z "$workflow_id" || "$workflow_id" == "null" ]]; then
   echo "::notice::Could not determine workflow ID — running in summary-only mode"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -737,7 +737,7 @@ for ((i=0; i<${#args[@]}; i++)); do
 done
 
 case $count in
-  1) echo '{"workflow_id": 12345}' ;;
+  1) printf '%s\n%s' '{"workflow_id": 12345}' '200' ;;
   2) echo '{"default_branch": "main"}' ;;
   3) echo '{"workflow_runs": [{"id": 67890}]}' ;;
   4) echo '{"artifacts": [{"name": "lcov-baseline", "expired": false, "archive_download_url": "https://example.com/artifact.zip"}]}' ;;
@@ -816,7 +816,7 @@ count=$((count + 1))
 echo "$count" > "$counter_file"
 
 case $count in
-  1) echo '{"workflow_id": 12345}' ;;
+  1) printf '%s\n%s' '{"workflow_id": 12345}' '200' ;;
   2) echo '{"default_branch": "main"}' ;;
   3) echo '{"workflow_runs": []}' ;;
 esac
@@ -868,7 +868,7 @@ count=$((count + 1))
 echo "$count" > "$counter_file"
 
 case $count in
-  1) echo '{"workflow_id": 12345}' ;;
+  1) printf '%s\n%s' '{"workflow_id": 12345}' '200' ;;
   2) echo '{"default_branch": "main"}' ;;
   3) echo '{"workflow_runs": [{"id": 67890}]}' ;;
   4) echo '{"artifacts": []}' ;;
@@ -983,7 +983,7 @@ for ((i=0; i<${#args[@]}; i++)); do
 done
 
 case $count in
-  1) echo '{"workflow_id": 12345}' ;;
+  1) printf '%s\n%s' '{"workflow_id": 12345}' '200' ;;
   2) echo '{"default_branch": "main"}' ;;
   3) echo '{"workflow_runs": [{"id": 67890}]}' ;;
   4) echo '{"artifacts": [{"name": "lcov-baseline", "expired": false, "archive_download_url": "https://example.com/artifact.zip"}]}' ;;
@@ -1065,7 +1065,7 @@ for ((i=0; i<${#args[@]}; i++)); do
 done
 
 case $count in
-  1) echo '{"workflow_id": 12345}' ;;
+  1) printf '%s\n%s' '{"workflow_id": 12345}' '200' ;;
   2) echo '{"default_branch": "main"}' ;;
   3) echo '{"workflow_runs": [{"id": 67890}]}' ;;
   4) echo '{"artifacts": [{"name": "lcov-baseline", "expired": false, "archive_download_url": "https://example.com/artifact.zip"}]}' ;;
@@ -1369,6 +1369,60 @@ fi
 
 rm -f "$py_baseline" "$py_current"
 cleanup_git_repo "$tmpdir"
+
+# ---------------------------------------------------------------------------
+# Test 26: Baseline retrieval — HTTP 403 permission error
+# ---------------------------------------------------------------------------
+run_test "Baseline retrieval: HTTP 403 mentions actions:read permission"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-test-XXXXXX")"
+
+mock_bin="${tmpdir}/mock-bin"
+mkdir -p "$mock_bin"
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+# Return a 403 response body and status code (simulating missing actions:read)
+printf '%s\n%s' '{"message":"Resource not accessible by integration"}' '403'
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
+github_output="${tmpdir}/github_output"
+: > "$github_output"
+
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_OUTPUT="$github_output" \
+  GITHUB_REPOSITORY="owner/repo" \
+  GITHUB_RUN_ID="11111" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$RETRIEVE_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0 (graceful fallback)"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+if grep -q "downloaded=false" "$github_output"; then
+  pass "output contains downloaded=false"
+else
+  fail "output missing downloaded=false"
+fi
+
+if echo "$output" | grep -q "actions: read"; then
+  pass "notice message mentions 'actions: read' permission"
+else
+  fail "notice message should mention 'actions: read' permission"
+fi
+
+if echo "$output" | grep -q "HTTP 403"; then
+  pass "notice message mentions HTTP 403"
+else
+  fail "notice message should mention HTTP 403"
+fi
+
+rm -rf "$tmpdir"
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary

- **`retrieve-baseline.sh`**: Capture HTTP status code from the first API call (`/actions/runs/{run_id}`). On 403 or 404, emit a `::notice::` that specifically mentions the `actions: read` permission requirement, instead of the generic "could not determine workflow ID" message.
- **`README.md`**: Add `permissions: { actions: read, contents: read, pull-requests: write }` to the full workflow example and a note after the basic usage example linking to the Token permissions section.
- **`test/run-tests.sh`**: Add Test 26 verifying the HTTP 403 path produces the correct notice. Update existing test mocks to handle the new `-w` flag on the first curl call.

## Test plan

- [x] All 26 tests pass (`./test/run-tests.sh`)