### PR TITLE
feat: consolidate coverage-label PR comments into a single comment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ A reusable composite GitHub Action (pure bash, no Node.js) that parses LCOV cove
   - `common.sh` — `write_output()`, `append_summary()`
   - `lcov.sh` — LCOV parsing (`parse_lcov_overall`, `parse_lcov_per_file`), numeric helpers (`coverage_pct`, `compare_floats`, `format_pct`), extension extraction
   - `filter.sh` — Ignore-pattern matching (`should_ignore_file`, `filter_lcov_file`)
+  - `comment.sh` — PR comment section management (`build_section`, `extract_section_keys`, `replace_section`). All coverage labels share one consolidated PR comment; each label occupies its own section, independently updated via read-modify-write with retry.
 - **`action.yml`** — GitHub Actions composite action definition. Calls `retrieve-baseline.sh` then `check-coverage.sh`.
 
 ## Testing
@@ -18,7 +19,7 @@ A reusable composite GitHub Action (pure bash, no Node.js) that parses LCOV cove
 ./test/run-tests.sh
 ```
 
-Tests live in `test/tests/*.sh` (13 files, ~59 tests). They are **sourced** by `test/run-tests.sh`, not executed as subprocesses. Test helpers are in `test/helpers/`. Fixtures are in `test/fixtures/`.
+Tests live in `test/tests/*.sh` (14 files, ~62 tests). They are **sourced** by `test/run-tests.sh`, not executed as subprocesses. Test helpers are in `test/helpers/`. Fixtures are in `test/fixtures/`.
 
 ## Key conventions
 

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ If your repo produces multiple LCOV files (e.g., Go backend + TypeScript fronten
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-Each label gets its own PR comment (identified by a label-specific HTML marker), baseline artifact (e.g., `lcov-baseline-go`), and PR coverage artifact (e.g., `lcov-coverage-frontend`).
+All labels share a single consolidated PR comment, with each label occupying its own section that is independently updated. Each label also gets its own baseline artifact (e.g., `lcov-baseline-go`) and PR coverage artifact (e.g., `lcov-coverage-frontend`).
 
-Labels are normalized to lowercase alphanumeric characters and hyphens. If the action detects that multiple coverage checks are running without consistent `coverage-label` usage (e.g., some steps have labels and others don't), a visible warning is added to the PR comment.
+Labels are normalized to lowercase alphanumeric characters and hyphens.
 
 ## Inputs
 
@@ -132,7 +132,7 @@ Labels are normalized to lowercase alphanumeric characters and hyphens. If the a
 | `path`                      | no       | `lib/`               | Path prefixes for file-level checks, one per line. Empty = all paths                      |
 | `changed-file-no-decrease`  | no       | `true`               | Require that per-file coverage of modified files does not decrease vs baseline            |
 | `ignore-patterns`           | no       | `''`                 | File patterns to exclude from coverage checks (one glob pattern per line)                 |
-| `coverage-label`            | no       | `''`                 | Label to distinguish multiple coverage checks. Enables separate PR comments and artifacts |
+| `coverage-label`            | no       | `''`                 | Label to distinguish multiple coverage checks. Each label gets its own section in the consolidated PR comment and its own baseline artifact |
 | `github-token`              | no       | `''`                 | GitHub token for PR comments and artifact management. If empty, runs in summary-only mode |
 
 ## Outputs
@@ -201,7 +201,7 @@ Common examples:
 
 ### PR comments
 
-When `github-token` is provided and the action runs in a pull request context, a markdown comment is posted (or updated) on the PR. The comment is identified by a hidden HTML marker so it gets updated on subsequent pushes rather than creating duplicate comments. When `coverage-label` is provided, each label gets its own comment, preventing multiple coverage checks from overwriting each other.
+When `github-token` is provided and the action runs in a pull request context, a markdown comment is posted (or updated) on the PR. All coverage checks share a single consolidated comment, identified by a hidden HTML marker. Each `coverage-label` occupies its own section within the comment, independently updated via a read-modify-write cycle with retry to handle concurrent updates. Old-format per-label comments (from previous versions) are automatically cleaned up on the first run.
 
 ### Shallow clones and fetch-depth
 
@@ -218,7 +218,7 @@ For new/modified file detection, the action needs access to both the base and he
 - **Modified file not in baseline LCOV**: Skipped (new to coverage tracking)
 - **Modified file not in current LCOV**: Treated as 0% coverage
 - **Ignored files**: Completely excluded from LCOV data, overall coverage, and per-file checks
-- **Changing a `coverage-label`**: Renaming a label orphans the old comment (it won't be updated or deleted) and the old baseline artifact is no longer used. The new label starts fresh.
+- **Changing a `coverage-label`**: Renaming a label leaves the old section in the consolidated comment (it won't be updated or removed until the comment is recreated). The old baseline artifact is no longer used. The new label starts fresh.
 
 ## Project structure
 
@@ -228,6 +228,7 @@ scripts/
     common.sh          # Shared helpers (write_output, append_summary)
     lcov.sh            # LCOV parsing and numeric helpers
     filter.sh          # File filtering / ignore-pattern logic
+    comment.sh         # PR comment section management
   check-coverage.sh    # Main coverage checking logic
   retrieve-baseline.sh # Baseline artifact retrieval
 test/

--- a/README.md
+++ b/README.md
@@ -125,15 +125,15 @@ Labels are normalized to lowercase alphanumeric characters and hyphens.
 
 ## Inputs
 
-| Input                       | Required | Default              | Description                                                                               |
-| --------------------------- | -------- | -------------------- | ----------------------------------------------------------------------------------------- |
-| `lcov-file`                 | no       | `coverage/lcov.info` | Path to current LCOV coverage file                                                        |
-| `new-file-minimum-coverage` | no       | `80`                 | Minimum coverage percentage for new files (0-100)                                         |
-| `path`                      | no       | `lib/`               | Path prefixes for file-level checks, one per line. Empty = all paths                      |
-| `changed-file-no-decrease`  | no       | `true`               | Require that per-file coverage of modified files does not decrease vs baseline            |
-| `ignore-patterns`           | no       | `''`                 | File patterns to exclude from coverage checks (one glob pattern per line)                 |
+| Input                       | Required | Default              | Description                                                                                                                                 |
+| --------------------------- | -------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lcov-file`                 | no       | `coverage/lcov.info` | Path to current LCOV coverage file                                                                                                          |
+| `new-file-minimum-coverage` | no       | `80`                 | Minimum coverage percentage for new files (0-100)                                                                                           |
+| `path`                      | no       | `lib/`               | Path prefixes for file-level checks, one per line. Empty = all paths                                                                        |
+| `changed-file-no-decrease`  | no       | `true`               | Require that per-file coverage of modified files does not decrease vs baseline                                                              |
+| `ignore-patterns`           | no       | `''`                 | File patterns to exclude from coverage checks (one glob pattern per line)                                                                   |
 | `coverage-label`            | no       | `''`                 | Label to distinguish multiple coverage checks. Each label gets its own section in the consolidated PR comment and its own baseline artifact |
-| `github-token`              | no       | `''`                 | GitHub token for PR comments and artifact management. If empty, runs in summary-only mode |
+| `github-token`              | no       | `''`                 | GitHub token for PR comments and artifact management. If empty, runs in summary-only mode                                                   |
 
 ## Outputs
 
@@ -222,7 +222,7 @@ For new/modified file detection, the action needs access to both the base and he
 
 ## Project structure
 
-```
+```txt
 scripts/
   lib/
     common.sh          # Shared helpers (write_output, append_summary)

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -559,6 +559,9 @@ ${page_response}")"
         -H "Accept: application/vnd.github+json" \
         "${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/issues/comments/${old_id}" \
         || true)"
+      if [[ ! "$delete_status" =~ ^[0-9]+$ ]]; then
+        delete_status="000"
+      fi
       if [[ "$delete_status" -ge 200 && "$delete_status" -lt 300 ]]; then
         echo "  Cleaned up old-format comment (ID: ${old_id})"
       else

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -468,12 +468,6 @@ if [[ -n "$INPUT_GITHUB_TOKEN" && -n "${GITHUB_REPOSITORY:-}" && -n "$pr_number"
     all_comments="$(jq -s '.[0] + .[1]' <<< "${all_comments}
 ${page_response}")"
 
-    # If this page contains our marker, we have enough data — stop early
-    if echo "$page_response" | jq -e ".[] | select(.body | startswith(\"${comment_marker}\"))" > /dev/null 2>&1; then
-      rm -f "$comments_header_file"
-      break
-    fi
-
     # Check Link header for next page
     has_next="$(grep -i '^link:' "$comments_header_file" | grep -o 'rel="next"' || true)"
     rm -f "$comments_header_file"

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -30,6 +30,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"
 source "${SCRIPT_DIR}/lib/lcov.sh"
 source "${SCRIPT_DIR}/lib/filter.sh"
+source "${SCRIPT_DIR}/lib/comment.sh"
 
 # ---------------------------------------------------------------------------
 # Temp-file cleanup — filter_lcov_file creates temp files that we must remove
@@ -427,21 +428,26 @@ if [[ -n "$INPUT_GITHUB_TOKEN" && -n "${GITHUB_REPOSITORY:-}" && -n "$pr_number"
   echo ""
   echo "-- Posting PR Comment --"
 
-  # Build comment marker (namespaced by label if provided)
+  # All coverage labels share one comment, identified by a single marker
+  comment_marker="<!-- lcov-coverage-check -->"
+
+  # Section key: the coverage label, or "default" for unlabeled runs
   if [[ -n "$INPUT_COVERAGE_LABEL" ]]; then
-    comment_marker="<!-- lcov-coverage-check:${INPUT_COVERAGE_LABEL} -->"
+    section_key="$INPUT_COVERAGE_LABEL"
   else
-    comment_marker="<!-- lcov-coverage-check -->"
+    section_key="default"
   fi
 
-  # Source tag to detect when different runs share the same (unlabeled) marker
+  # Source tag embedded per-section (for debugging which job produced a section)
   # Collapse runs of 2+ hyphens to prevent breaking HTML comment structure
   safe_job="$(echo "${GITHUB_JOB:-unknown}" | sed 's/--*/-/g')"
   safe_lcov="$(echo "$ORIGINAL_LCOV_FILE" | sed 's/--*/-/g')"
   source_id="${safe_job}:${safe_lcov}"
-  source_tag="<!-- lcov-coverage-source:${source_id} -->"
 
-  # Fetch PR comments (paginated, early-exit) for collision detection and existing-comment lookup
+  # Build this run's section (convert literal \n in summary_md to actual newlines)
+  new_section="$(build_section "$section_key" "$source_id" "$(echo -e "$summary_md")")"
+
+  # Fetch PR comments (paginated, early-exit) for existing-comment lookup
   all_comments="[]"
   comments_page=1
   while true; do
@@ -481,61 +487,79 @@ ${page_response}")"
     fi
   done
 
-  # --- Collision detection ---
-  collision_warning=""
-
-  # Find all comments that start with any lcov-coverage-check marker
-  all_coverage_markers="$(echo "$all_comments" | jq -r '.[].body' 2>/dev/null \
-    | grep -o '<!-- lcov-coverage-check[^>]*-->' || true)"
-
-  if [[ -n "$INPUT_COVERAGE_LABEL" ]]; then
-    # Current run is labeled — warn if an unlabeled comment exists
-    if echo "$all_coverage_markers" | grep -qx '<!-- lcov-coverage-check -->'; then
-      collision_warning="\n\n> **Warning:** Another coverage check on this PR runs without \`coverage-label\`. Add labels to all coverage check steps to prevent collisions.\n"
-    fi
-  else
-    # Current run is unlabeled — check for two types of collision
-    # 1. Labeled comments exist (partial label adoption)
-    if echo "$all_coverage_markers" | grep -q '<!-- lcov-coverage-check:'; then
-      collision_warning="\n\n> **Warning:** Other coverage checks on this PR use \`coverage-label\`. Add a \`coverage-label\` to this step to prevent comment collisions.\n"
-    fi
-
-    # 2. Existing unlabeled comment from a different source (overwrite)
-    existing_source="$(echo "$all_comments" \
-      | jq -r ".[] | select(.body | startswith(\"${comment_marker}\")) | .body" \
-      | grep -o '<!-- lcov-coverage-source:[^>]*-->' \
-      | head -1 || true)"
-    if [[ -n "$existing_source" && "$existing_source" != "$source_tag" ]]; then
-      # Different source is about to be overwritten — this is the strongest signal
-      collision_warning="\n\n> **Warning:** This comment was overwritten by a different coverage check. Use \`coverage-label\` on each step to give them separate comments.\n"
-    fi
-  fi
-
-  comment_body="${comment_marker}\n${source_tag}\n${summary_md}${collision_warning}"
-  comment_body_json="$(echo -e "$comment_body" | jq -Rs '.')"
-
-  # Look for existing comment with our specific marker
+  # Look for existing consolidated comment
   existing_comment_id="$(echo "$all_comments" \
     | jq -r ".[] | select(.body | startswith(\"${comment_marker}\")) | .id" \
     | head -1 || true
   )"
 
   if [[ -n "$existing_comment_id" && "$existing_comment_id" != "null" ]]; then
-    # Update existing comment
-    curl -s -X PATCH \
-      -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
-      -H "Accept: application/vnd.github+json" \
-      "${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/issues/comments/${existing_comment_id}" \
-      -d "{\"body\": ${comment_body_json}}" > /dev/null
-    echo "  Updated existing PR comment (ID: ${existing_comment_id})"
+    # Merge our section into the existing comment's body
+    existing_body="$(echo "$all_comments" \
+      | jq -r --argjson cid "$existing_comment_id" '.[] | select(.id == $cid) | .body')"
+    comment_body="$(replace_section "$existing_body" "$section_key" "$new_section")"
+    comment_body_json="$(printf '%s' "$comment_body" | jq -Rs '.')"
+
+    # Update with retry: re-read and retry if a concurrent writer clobbered our section
+    max_retries=3
+    section_verified=false
+    for attempt in $(seq 1 $max_retries); do
+      curl -s -X PATCH \
+        -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        "${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/issues/comments/${existing_comment_id}" \
+        -d "{\"body\": ${comment_body_json}}" > /dev/null
+
+      # Verify our section survived (another writer may have clobbered it)
+      verify_body="$(
+        curl -s \
+          -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
+          -H "Accept: application/vnd.github+json" \
+          "${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/issues/comments/${existing_comment_id}" \
+          | jq -r '.body // ""' || true
+      )"
+      if echo "$verify_body" | grep -q "<!-- lcov-section:${section_key} -->"; then
+        section_verified=true
+        break
+      fi
+
+      if [[ $attempt -lt $max_retries ]]; then
+        echo "  Retry ${attempt}: comment was modified concurrently, re-merging..."
+        comment_body="$(replace_section "$verify_body" "$section_key" "$new_section")"
+        comment_body_json="$(printf '%s' "$comment_body" | jq -Rs '.')"
+      fi
+    done
+    if [[ "$section_verified" == "true" ]]; then
+      echo "  Updated existing PR comment (ID: ${existing_comment_id})"
+    else
+      echo "::warning::PR comment updated but section verification failed after ${max_retries} retries (possible concurrent update conflict)"
+      echo "  Updated existing PR comment (ID: ${existing_comment_id}) — verification failed"
+    fi
   else
-    # Create new comment
+    # Create new comment with just this section
+    comment_body="$(printf '%s\n%s\n' "${comment_marker}" "${new_section}")"
+    comment_body_json="$(printf '%s' "$comment_body" | jq -Rs '.')"
+
     curl -s -X POST \
       -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
       -H "Accept: application/vnd.github+json" \
       "${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
       -d "{\"body\": ${comment_body_json}}" > /dev/null
     echo "  Created new PR comment"
+  fi
+
+  # Clean up old-format per-label comments (migration from previous version)
+  old_label_comment_ids="$(echo "$all_comments" \
+    | jq -r '.[] | select(.body | test("^<!-- lcov-coverage-check:")) | .id' 2>/dev/null || true)"
+  if [[ -n "$old_label_comment_ids" ]]; then
+    while IFS= read -r old_id; do
+      [[ -z "$old_id" ]] && continue
+      curl -s -X DELETE \
+        -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        "${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/issues/comments/${old_id}" > /dev/null
+      echo "  Cleaned up old-format comment (ID: ${old_id})"
+    done <<< "$old_label_comment_ids"
   fi
 fi
 

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -445,7 +445,7 @@ if [[ -n "$INPUT_GITHUB_TOKEN" && -n "${GITHUB_REPOSITORY:-}" && -n "$pr_number"
   source_id="${safe_job}:${safe_lcov}"
 
   # Build this run's section (convert literal \n in summary_md to actual newlines)
-  new_section="$(build_section "$section_key" "$source_id" "$(echo -e "$summary_md")")"
+  new_section="$(build_section "$section_key" "$source_id" "$(printf '%b' "$summary_md")")"
 
   # Fetch PR comments (paginated, early-exit) for existing-comment lookup
   all_comments="[]"
@@ -554,11 +554,16 @@ ${page_response}")"
   if [[ -n "$old_label_comment_ids" ]]; then
     while IFS= read -r old_id; do
       [[ -z "$old_id" ]] && continue
-      curl -s -X DELETE \
+      delete_status="$(curl -s -o /dev/null -w '%{http_code}' -X DELETE \
         -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
         -H "Accept: application/vnd.github+json" \
-        "${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/issues/comments/${old_id}" > /dev/null
-      echo "  Cleaned up old-format comment (ID: ${old_id})"
+        "${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/issues/comments/${old_id}" \
+        || true)"
+      if [[ "$delete_status" -ge 200 && "$delete_status" -lt 300 ]]; then
+        echo "  Cleaned up old-format comment (ID: ${old_id})"
+      else
+        echo "  Warning: failed to clean up old-format comment (ID: ${old_id}), HTTP status: ${delete_status}"
+      fi
     done <<< "$old_label_comment_ids"
   fi
 fi

--- a/scripts/lib/comment.sh
+++ b/scripts/lib/comment.sh
@@ -2,6 +2,13 @@
 [[ -n "${_LIB_COMMENT_LOADED:-}" ]] && return 0
 _LIB_COMMENT_LOADED=1
 
+# _sanitize_section_key KEY
+#   Strips any characters that are not [a-z0-9-] from a section key.
+#   Prevents path-traversal or filesystem issues when keys are used as filenames.
+_sanitize_section_key() {
+  printf '%s' "$1" | tr -cd 'a-z0-9-'
+}
+
 # build_section KEY SOURCE_ID CONTENT
 #   Wraps CONTENT in section delimiters with an embedded source tag.
 #   CONTENT should contain actual newlines (not literal \n sequences).
@@ -34,35 +41,44 @@ replace_section() {
   local existing_keys
   existing_keys="$(extract_section_keys "$body")"
 
-  # Build a temporary directory to hold sections; clean up on any exit path
+  # Build a temporary directory to hold sections
   local tmpdir
   tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-sections-XXXXXX")"
 
+  # Ensure tmpdir is cleaned up on any exit path (including set -e failures)
+  trap 'rm -rf "$tmpdir"' RETURN
+
   # Extract each existing section (except the one we're replacing) into files.
   # Uses index() for matching to tolerate trailing whitespace on marker lines.
+  # Keys are sanitized before use as filenames to prevent path traversal.
   if [[ -n "$existing_keys" ]]; then
     while IFS= read -r k; do
       [[ -z "$k" ]] && continue
       if [[ "$k" == "$key" ]]; then
         continue  # skip — we'll use the new section instead
       fi
+      local safe_k
+      safe_k="$(_sanitize_section_key "$k")"
+      [[ -z "$safe_k" ]] && continue
       echo "$body" | awk -v start="<!-- lcov-section:${k} -->" \
                           -v end="<!-- lcov-section-end:${k} -->" '
         index($0, start) == 1 { found=1 }
         found { print }
         index($0, end) == 1 { found=0 }
-      ' > "${tmpdir}/${k}"
+      ' > "${tmpdir}/${safe_k}"
     done <<< "$existing_keys"
   fi
 
-  # Write the new/replacement section
-  printf '%s\n' "$new_section" > "${tmpdir}/${key}"
+  # Write the new/replacement section (key is already sanitized by the caller)
+  local safe_key
+  safe_key="$(_sanitize_section_key "$key")"
+  printf '%s\n' "$new_section" > "${tmpdir}/${safe_key}"
 
   # Sort keys: "default" first, then alphabetical
   local sorted_keys
   sorted_keys="$( {
     ls "$tmpdir" | grep -x 'default' || true
-    ls "$tmpdir" | grep -vx 'default' | sort
+    ls "$tmpdir" | grep -vx 'default' | sort || true
   } )"
 
   # Rebuild comment
@@ -72,6 +88,5 @@ replace_section() {
     result+=$'\n'"$(cat "${tmpdir}/${k}")"
   done <<< "$sorted_keys"
 
-  rm -rf "$tmpdir"
   echo "$result"
 }

--- a/scripts/lib/comment.sh
+++ b/scripts/lib/comment.sh
@@ -1,0 +1,77 @@
+# Source guard — prevent double-sourcing
+[[ -n "${_LIB_COMMENT_LOADED:-}" ]] && return 0
+_LIB_COMMENT_LOADED=1
+
+# build_section KEY SOURCE_ID CONTENT
+#   Wraps CONTENT in section delimiters with an embedded source tag.
+#   CONTENT should contain actual newlines (not literal \n sequences).
+#   Output is written to stdout with actual newlines.
+build_section() {
+  local key="$1" source_id="$2" content="$3"
+  printf '%s\n%s\n%s\n%s\n' \
+    "<!-- lcov-section:${key} -->" \
+    "<!-- lcov-section-source:${source_id} -->" \
+    "$content" \
+    "<!-- lcov-section-end:${key} -->"
+}
+
+# extract_section_keys BODY
+#   Prints newline-separated section keys found in BODY.
+extract_section_keys() {
+  local body="$1"
+  echo "$body" | grep -o '<!-- lcov-section:[^ ]*' | sed 's/<!-- lcov-section://' || true
+}
+
+# replace_section BODY KEY NEW_SECTION
+#   Replaces the section for KEY in BODY (or appends it if absent).
+#   Returns the rebuilt comment: top-level marker, then sections sorted
+#   with "default" first and the rest alphabetical.
+#   All inputs/outputs use actual newlines (not literal \n).
+replace_section() {
+  local body="$1" key="$2" new_section="$3"
+
+  # Collect all existing section keys
+  local existing_keys
+  existing_keys="$(extract_section_keys "$body")"
+
+  # Build a temporary directory to hold sections; clean up on any exit path
+  local tmpdir
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-sections-XXXXXX")"
+
+  # Extract each existing section (except the one we're replacing) into files.
+  # Uses index() for matching to tolerate trailing whitespace on marker lines.
+  if [[ -n "$existing_keys" ]]; then
+    while IFS= read -r k; do
+      [[ -z "$k" ]] && continue
+      if [[ "$k" == "$key" ]]; then
+        continue  # skip — we'll use the new section instead
+      fi
+      echo "$body" | awk -v start="<!-- lcov-section:${k} -->" \
+                          -v end="<!-- lcov-section-end:${k} -->" '
+        index($0, start) == 1 { found=1 }
+        found { print }
+        index($0, end) == 1 { found=0 }
+      ' > "${tmpdir}/${k}"
+    done <<< "$existing_keys"
+  fi
+
+  # Write the new/replacement section
+  printf '%s\n' "$new_section" > "${tmpdir}/${key}"
+
+  # Sort keys: "default" first, then alphabetical
+  local sorted_keys
+  sorted_keys="$( {
+    ls "$tmpdir" | grep -x 'default' || true
+    ls "$tmpdir" | grep -vx 'default' | sort
+  } )"
+
+  # Rebuild comment
+  local result="<!-- lcov-coverage-check -->"
+  while IFS= read -r k; do
+    [[ -z "$k" ]] && continue
+    result+=$'\n'"$(cat "${tmpdir}/${k}")"
+  done <<< "$sorted_keys"
+
+  rm -rf "$tmpdir"
+  echo "$result"
+}

--- a/scripts/lib/comment.sh
+++ b/scripts/lib/comment.sh
@@ -26,7 +26,7 @@ build_section() {
 #   Prints newline-separated section keys found in BODY.
 extract_section_keys() {
   local body="$1"
-  echo "$body" | grep -o '<!-- lcov-section:[^ ]*' | sed 's/<!-- lcov-section://' || true
+  echo "$body" | grep -o '^<!-- lcov-section:[^>]* -->' | sed -e 's/^<!-- lcov-section://' -e 's/ -->$//' || true
 }
 
 # replace_section BODY KEY NEW_SECTION

--- a/test/tests/04-pr-comments.sh
+++ b/test/tests/04-pr-comments.sh
@@ -62,6 +62,19 @@ else
   fail "curl not called with correct PR number"
 fi
 
+# Verify the comment body uses section markers (default section for unlabeled runs)
+if grep -q 'lcov-section:default' "$curl_log" 2>/dev/null; then
+  pass "comment body contains section marker for default"
+else
+  fail "comment body missing section marker 'lcov-section:default'"
+fi
+
+if grep -q 'lcov-section-end:default' "$curl_log" 2>/dev/null; then
+  pass "comment body contains section end marker for default"
+else
+  fail "comment body missing section end marker 'lcov-section-end:default'"
+fi
+
 rm -f "$event_payload"
 rm -rf "$mock_bin"
 
@@ -133,14 +146,15 @@ fi
 rm -f "$event_payload"
 
 # ---------------------------------------------------------------------------
-# Test 14: PR comment updates existing comment
+# Test 14: PR comment updates existing consolidated comment
 # ---------------------------------------------------------------------------
 run_test "PR comment updates existing comment when marker found"
 
 event_payload="$(mktemp "${TMPDIR:-/tmp}/event-payload-XXXXXX.json")"
 echo '{"pull_request": {"number": 7}}' > "$event_payload"
 
-# Mock curl that returns an existing comment on GET
+# Mock curl that returns an existing consolidated comment on GET,
+# and returns the updated body on verify GET
 mock_bin="$(mktemp -d "${TMPDIR:-/tmp}/mock-bin-XXXXXX")"
 curl_log="${mock_bin}/curl.log"
 cat > "${mock_bin}/curl" <<'MOCKCURL'
@@ -148,9 +162,12 @@ cat > "${mock_bin}/curl" <<'MOCKCURL'
 echo "$@" >> "$(dirname "$0")/curl.log"
 if echo "$@" | grep -q "\-X POST\|\-X PATCH"; then
   echo '{}'
+elif echo "$@" | grep -q "issues/comments/99999"; then
+  # Verify GET after PATCH — return body with the default section
+  printf '{"body": "<!-- lcov-coverage-check -->\\n<!-- lcov-section:default -->\\nreport\\n<!-- lcov-section-end:default -->"}'
 else
-  # Return a comment with the marker
-  echo '[{"id": 99999, "body": "<!-- lcov-coverage-check -->\nold report"}]'
+  # List comments — return existing consolidated comment with a "go" section
+  echo '[{"id": 99999, "body": "<!-- lcov-coverage-check -->\n<!-- lcov-section:go -->\n<!-- lcov-section-source:go-job:go.lcov -->\n## Coverage Report — go\n<!-- lcov-section-end:go -->"}]'
 fi
 MOCKCURL
 chmod +x "${mock_bin}/curl"
@@ -187,6 +204,13 @@ if grep -q "\-X PATCH" "$curl_log" 2>/dev/null; then
   pass "curl used PATCH to update existing comment"
 else
   fail "curl should have used PATCH"
+fi
+
+# Verify the PATCH body contains both the existing "go" section and the new "default" section
+if grep -q 'lcov-section:go' "$curl_log" 2>/dev/null && grep -q 'lcov-section:default' "$curl_log" 2>/dev/null; then
+  pass "PATCH body contains both 'go' and 'default' sections"
+else
+  fail "PATCH body should contain both existing 'go' and new 'default' sections"
 fi
 
 rm -f "$event_payload"

--- a/test/tests/10-coverage-label.sh
+++ b/test/tests/10-coverage-label.sh
@@ -113,9 +113,9 @@ fi
 rm -f "$step_summary"
 
 # ---------------------------------------------------------------------------
-# Test 44: Coverage label — comment marker includes label
+# Test 44: Coverage label — section marker uses label as key
 # ---------------------------------------------------------------------------
-run_test "Coverage label: comment marker includes label"
+run_test "Coverage label: section marker uses label as key"
 
 event_payload="$(mktemp "${TMPDIR:-/tmp}/event-payload-XXXXXX.json")"
 echo '{"pull_request": {"number": 42}}' > "$event_payload"
@@ -157,19 +157,27 @@ else
   fail "expected exit code 0, got $exit_code"
 fi
 
-if grep -q 'lcov-coverage-check:go' "$curl_log" 2>/dev/null; then
-  pass "curl log contains labeled marker 'lcov-coverage-check:go'"
+# All runs use the same top-level marker
+if grep -q 'lcov-coverage-check -->' "$curl_log" 2>/dev/null; then
+  pass "curl log contains consolidated marker 'lcov-coverage-check'"
 else
-  fail "curl log missing labeled marker"
+  fail "curl log missing consolidated marker"
+fi
+
+# The label should appear as a section key, not in the top-level marker
+if grep -q 'lcov-section:go' "$curl_log" 2>/dev/null; then
+  pass "curl log contains section marker 'lcov-section:go'"
+else
+  fail "curl log missing section marker 'lcov-section:go'"
 fi
 
 rm -f "$event_payload"
 rm -rf "$mock_bin"
 
 # ---------------------------------------------------------------------------
-# Test 45: Coverage label — different labels produce different markers
+# Test 45: Coverage label — different labels produce different section keys
 # ---------------------------------------------------------------------------
-run_test "Coverage label: different labels produce different markers"
+run_test "Coverage label: different labels produce different section keys"
 
 event_payload="$(mktemp "${TMPDIR:-/tmp}/event-payload-XXXXXX.json")"
 echo '{"pull_request": {"number": 42}}' > "$event_payload"
@@ -234,28 +242,43 @@ INPUT_COVERAGE_LABEL="frontend" \
 INPUT_GITHUB_TOKEN="fake-token" \
 bash "$CHECK_SCRIPT" > /dev/null 2>&1 || true
 
-if grep -q 'lcov-coverage-check:go' "$curl_log_go" 2>/dev/null; then
-  pass "first run uses marker 'lcov-coverage-check:go'"
+# Both runs use the same top-level marker
+if grep -q 'lcov-coverage-check -->' "$curl_log_go" 2>/dev/null; then
+  pass "first run uses consolidated marker"
 else
-  fail "first run missing marker 'lcov-coverage-check:go'"
+  fail "first run missing consolidated marker"
 fi
 
-if grep -q 'lcov-coverage-check:frontend' "$curl_log_fe" 2>/dev/null; then
-  pass "second run uses marker 'lcov-coverage-check:frontend'"
+if grep -q 'lcov-coverage-check -->' "$curl_log_fe" 2>/dev/null; then
+  pass "second run uses consolidated marker"
 else
-  fail "second run missing marker 'lcov-coverage-check:frontend'"
+  fail "second run missing consolidated marker"
 fi
 
-if ! grep -q 'lcov-coverage-check:frontend' "$curl_log_go" 2>/dev/null; then
-  pass "first run does NOT contain 'frontend' marker"
+# Each run uses its own section key
+if grep -q 'lcov-section:go' "$curl_log_go" 2>/dev/null; then
+  pass "first run has section 'lcov-section:go'"
 else
-  fail "first run should not contain 'frontend' marker"
+  fail "first run missing section 'lcov-section:go'"
 fi
 
-if ! grep -q 'lcov-coverage-check:go' "$curl_log_fe" 2>/dev/null; then
-  pass "second run does NOT contain 'go' marker"
+if grep -q 'lcov-section:frontend' "$curl_log_fe" 2>/dev/null; then
+  pass "second run has section 'lcov-section:frontend'"
 else
-  fail "second run should not contain 'go' marker"
+  fail "second run missing section 'lcov-section:frontend'"
+fi
+
+# Each run does NOT contain the other's section key
+if ! grep -q 'lcov-section:frontend' "$curl_log_go" 2>/dev/null; then
+  pass "first run does NOT contain 'frontend' section"
+else
+  fail "first run should not contain 'frontend' section"
+fi
+
+if ! grep -q 'lcov-section:go' "$curl_log_fe" 2>/dev/null; then
+  pass "second run does NOT contain 'go' section"
+else
+  fail "second run should not contain 'go' section"
 fi
 
 rm -f "$event_payload"

--- a/test/tests/11-collision-detection.sh
+++ b/test/tests/11-collision-detection.sh
@@ -325,7 +325,10 @@ curl_log="${mock_bin}/curl.log"
 cat > "${mock_bin}/curl" <<'MOCKCURL'
 #!/usr/bin/env bash
 echo "$@" >> "$(dirname "$0")/curl.log"
-if echo "$@" | grep -q "\-X DELETE\|\-X POST\|\-X PATCH"; then
+if echo "$@" | grep -q "\-X DELETE" && echo "$@" | grep -q "\-w"; then
+  # DELETE with status check — return HTTP 204
+  echo -n '204'
+elif echo "$@" | grep -q "\-X DELETE\|\-X POST\|\-X PATCH"; then
   echo '{}'
 else
   echo '[{"id": 500, "body": "<!-- lcov-coverage-check:go -->\nold labeled report"}, {"id": 501, "body": "<!-- lcov-coverage-check:frontend -->\nold frontend report"}]'

--- a/test/tests/11-collision-detection.sh
+++ b/test/tests/11-collision-detection.sh
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------------
-# Test 48: Collision detection — labeled run finds unlabeled comment
+# Test 48: Section added to existing comment preserving other sections
 # ---------------------------------------------------------------------------
-run_test "Collision detection: labeled run finds unlabeled comment"
+run_test "Section consolidation: new section added alongside existing section"
 
 event_payload="$(mktemp "${TMPDIR:-/tmp}/event-payload-XXXXXX.json")"
 echo '{"pull_request": {"number": 42}}' > "$event_payload"
@@ -9,18 +9,326 @@ echo '{"pull_request": {"number": 42}}' > "$event_payload"
 mock_bin="$(mktemp -d "${TMPDIR:-/tmp}/mock-bin-XXXXXX")"
 curl_log="${mock_bin}/curl.log"
 
-# Create comments.json: an unlabeled comment exists but no labeled one for "go"
+# Existing comment has a "go" section; we're running with label "frontend"
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+echo "$@" >> "$(dirname "$0")/curl.log"
+if echo "$@" | grep -q "\-X POST\|\-X PATCH"; then
+  echo '{}'
+elif echo "$@" | grep -q "issues/comments/100"; then
+  # Verify GET — return body with both sections so retry check passes
+  printf '{"body": "<!-- lcov-coverage-check -->\\n<!-- lcov-section:frontend -->\\nfrontend report\\n<!-- lcov-section-end:frontend -->\\n<!-- lcov-section:go -->\\ngo report\\n<!-- lcov-section-end:go -->"}'
+else
+  cat "$(dirname "$0")/comments.json"
+fi
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
 cat > "${mock_bin}/comments.json" <<'COMMENTS'
-[{"id": 100, "body": "<!-- lcov-coverage-check -->\nold unlabeled report"}]
+[{"id": 100, "body": "<!-- lcov-coverage-check -->\n<!-- lcov-section:go -->\n<!-- lcov-section-source:go-job:go.lcov -->\n## Coverage Report — go\n<!-- lcov-section-end:go -->"}]
 COMMENTS
 
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_EVENT_PATH="$event_payload" \
+  GITHUB_REPOSITORY="owner/repo" \
+  GITHUB_JOB="fe-job" \
+  INPUT_LCOV_FILE="$FIXTURES_DIR/current.lcov.info" \
+  INPUT_LCOV_BASE="$FIXTURES_DIR/baseline.lcov.info" \
+  INPUT_BASE_REF="" \
+  INPUT_HEAD_REF="HEAD" \
+  INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
+  INPUT_PATH="lib/" \
+  INPUT_CHANGED_FILE_NO_DECREASE="true" \
+  INPUT_IGNORE_PATTERNS="" \
+  INPUT_COVERAGE_LABEL="frontend" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$CHECK_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+# Should PATCH (existing comment found)
+if grep -q '\-X PATCH' "$curl_log" 2>/dev/null; then
+  pass "curl used PATCH to update existing comment"
+else
+  fail "curl should have used PATCH"
+fi
+
+# PATCH body must contain both sections
+if grep -q 'lcov-section:go' "$curl_log" 2>/dev/null && grep -q 'lcov-section:frontend' "$curl_log" 2>/dev/null; then
+  pass "PATCH body contains both 'go' and 'frontend' sections"
+else
+  fail "PATCH body should contain both existing 'go' and new 'frontend' sections"
+fi
+
+rm -f "$event_payload"
+rm -rf "$mock_bin"
+
+# ---------------------------------------------------------------------------
+# Test 49: Section replaced/updated in existing comment
+# ---------------------------------------------------------------------------
+run_test "Section consolidation: existing section is replaced with updated content"
+
+event_payload="$(mktemp "${TMPDIR:-/tmp}/event-payload-XXXXXX.json")"
+echo '{"pull_request": {"number": 42}}' > "$event_payload"
+
+mock_bin="$(mktemp -d "${TMPDIR:-/tmp}/mock-bin-XXXXXX")"
+curl_log="${mock_bin}/curl.log"
+
+# Existing comment has a "go" section; we're running with label "go" again
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+echo "$@" >> "$(dirname "$0")/curl.log"
+if echo "$@" | grep -q "\-X POST\|\-X PATCH"; then
+  echo '{}'
+elif echo "$@" | grep -q "issues/comments/200"; then
+  # Verify GET — return body with updated go section
+  printf '{"body": "<!-- lcov-coverage-check -->\\n<!-- lcov-section:go -->\\nnew go report\\n<!-- lcov-section-end:go -->"}'
+else
+  cat "$(dirname "$0")/comments.json"
+fi
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
+cat > "${mock_bin}/comments.json" <<'COMMENTS'
+[{"id": 200, "body": "<!-- lcov-coverage-check -->\n<!-- lcov-section:go -->\n<!-- lcov-section-source:go-job:old.lcov -->\n## OLD Coverage Report — go\n<!-- lcov-section-end:go -->"}]
+COMMENTS
+
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_EVENT_PATH="$event_payload" \
+  GITHUB_REPOSITORY="owner/repo" \
+  GITHUB_JOB="go-job" \
+  INPUT_LCOV_FILE="$FIXTURES_DIR/current.lcov.info" \
+  INPUT_LCOV_BASE="$FIXTURES_DIR/baseline.lcov.info" \
+  INPUT_BASE_REF="" \
+  INPUT_HEAD_REF="HEAD" \
+  INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
+  INPUT_PATH="lib/" \
+  INPUT_CHANGED_FILE_NO_DECREASE="true" \
+  INPUT_IGNORE_PATTERNS="" \
+  INPUT_COVERAGE_LABEL="go" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$CHECK_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+if grep -q '\-X PATCH' "$curl_log" 2>/dev/null; then
+  pass "curl used PATCH to update existing comment"
+else
+  fail "curl should have used PATCH"
+fi
+
+# Updated body should contain the new section content, not the old
+if grep -q 'lcov-section:go' "$curl_log" 2>/dev/null; then
+  pass "PATCH body contains 'go' section"
+else
+  fail "PATCH body missing 'go' section"
+fi
+
+# Old content should be replaced
+if grep -q 'OLD Coverage Report' "$curl_log" 2>/dev/null; then
+  fail "PATCH body still contains old section content"
+else
+  pass "old section content was replaced"
+fi
+
+rm -f "$event_payload"
+rm -rf "$mock_bin"
+
+# ---------------------------------------------------------------------------
+# Test 50: Default section key used when no label
+# ---------------------------------------------------------------------------
+run_test "Section consolidation: default section key used when no label"
+
+event_payload="$(mktemp "${TMPDIR:-/tmp}/event-payload-XXXXXX.json")"
+echo '{"pull_request": {"number": 42}}' > "$event_payload"
+
+mock_bin="$(mktemp -d "${TMPDIR:-/tmp}/mock-bin-XXXXXX")"
+curl_log="${mock_bin}/curl.log"
 cat > "${mock_bin}/curl" <<'MOCKCURL'
 #!/usr/bin/env bash
 echo "$@" >> "$(dirname "$0")/curl.log"
 if echo "$@" | grep -q "\-X POST\|\-X PATCH"; then
   echo '{}'
 else
-  cat "$(dirname "$0")/comments.json"
+  echo '[]'
+fi
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_EVENT_PATH="$event_payload" \
+  GITHUB_REPOSITORY="owner/repo" \
+  GITHUB_JOB="test-job" \
+  INPUT_LCOV_FILE="$FIXTURES_DIR/current.lcov.info" \
+  INPUT_LCOV_BASE="$FIXTURES_DIR/baseline.lcov.info" \
+  INPUT_BASE_REF="" \
+  INPUT_HEAD_REF="HEAD" \
+  INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
+  INPUT_PATH="lib/" \
+  INPUT_CHANGED_FILE_NO_DECREASE="true" \
+  INPUT_IGNORE_PATTERNS="" \
+  INPUT_COVERAGE_LABEL="" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$CHECK_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+if grep -q 'lcov-section:default' "$curl_log" 2>/dev/null; then
+  pass "unlabeled run uses section key 'default'"
+else
+  fail "unlabeled run should use section key 'default'"
+fi
+
+if grep -q 'lcov-section-end:default' "$curl_log" 2>/dev/null; then
+  pass "unlabeled run has section end marker for 'default'"
+else
+  fail "unlabeled run missing section end marker for 'default'"
+fi
+
+rm -f "$event_payload"
+rm -rf "$mock_bin"
+
+# ---------------------------------------------------------------------------
+# Test 50b: Backwards compat — old-format comment without sections is updated
+# ---------------------------------------------------------------------------
+run_test "Section consolidation: old-format comment (no sections) gets section added"
+
+event_payload="$(mktemp "${TMPDIR:-/tmp}/event-payload-XXXXXX.json")"
+echo '{"pull_request": {"number": 42}}' > "$event_payload"
+
+mock_bin="$(mktemp -d "${TMPDIR:-/tmp}/mock-bin-XXXXXX")"
+curl_log="${mock_bin}/curl.log"
+
+# Existing comment has the consolidated marker but NO section markers (old format)
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+echo "$@" >> "$(dirname "$0")/curl.log"
+if echo "$@" | grep -q "\-X POST\|\-X PATCH"; then
+  echo '{}'
+elif echo "$@" | grep -q "issues/comments/300" && ! echo "$@" | grep -q "\-D"; then
+  # Verify GET — return body with the new section
+  printf '{"body": "<!-- lcov-coverage-check -->\\n<!-- lcov-section:default -->\\nreport\\n<!-- lcov-section-end:default -->"}'
+else
+  # Old-format comment: marker + content but no section markers
+  echo '[{"id": 300, "body": "<!-- lcov-coverage-check -->\n<!-- lcov-coverage-source:old-job:old.lcov -->\n## Old Coverage Report\nSome old content"}]'
+fi
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_EVENT_PATH="$event_payload" \
+  GITHUB_REPOSITORY="owner/repo" \
+  GITHUB_JOB="test-job" \
+  INPUT_LCOV_FILE="$FIXTURES_DIR/current.lcov.info" \
+  INPUT_LCOV_BASE="$FIXTURES_DIR/baseline.lcov.info" \
+  INPUT_BASE_REF="" \
+  INPUT_HEAD_REF="HEAD" \
+  INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
+  INPUT_PATH="lib/" \
+  INPUT_CHANGED_FILE_NO_DECREASE="true" \
+  INPUT_IGNORE_PATTERNS="" \
+  INPUT_COVERAGE_LABEL="" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$CHECK_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+# Should PATCH (found the existing comment by marker)
+if grep -q '\-X PATCH' "$curl_log" 2>/dev/null; then
+  pass "curl used PATCH to update old-format comment"
+else
+  fail "curl should have used PATCH"
+fi
+
+# The PATCH body should include a section marker (the old body had none)
+if grep -q 'lcov-section:default' "$curl_log" 2>/dev/null; then
+  pass "PATCH body contains new section marker"
+else
+  fail "PATCH body should contain section marker for default"
+fi
+
+if echo "$output" | grep -q "Updated existing PR comment (ID: 300)"; then
+  pass "output confirms existing comment updated"
+else
+  fail "output missing update confirmation"
+fi
+
+rm -f "$event_payload"
+rm -rf "$mock_bin"
+
+# ---------------------------------------------------------------------------
+# Test 51: Sections are sorted (default first, then alphabetical)
+# ---------------------------------------------------------------------------
+run_test "Section consolidation: sections are sorted correctly"
+
+# Source the comment library to test replace_section directly
+source "$SCRIPT_DIR/../scripts/lib/comment.sh"
+
+existing_body="$(printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+  '<!-- lcov-coverage-check -->' \
+  '<!-- lcov-section:zebra -->' \
+  'zebra content' \
+  '<!-- lcov-section-end:zebra -->' \
+  '<!-- lcov-section:alpha -->' \
+  'alpha content' \
+  '<!-- lcov-section-end:alpha -->')"
+
+new_section="$(build_section 'default' 'job:file' 'default content')"
+result="$(replace_section "$existing_body" 'default' "$new_section")"
+
+# Extract section keys in order from the result
+keys_in_order="$(echo "$result" | grep -o '<!-- lcov-section:[^ ]*' | sed 's/<!-- lcov-section://')"
+expected="$(printf 'default\nalpha\nzebra')"
+
+if [[ "$keys_in_order" == "$expected" ]]; then
+  pass "sections are sorted: default first, then alphabetical"
+else
+  fail "sections not sorted correctly. Got: $(echo "$keys_in_order" | tr '\n' ','). Expected: default,alpha,zebra"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 52: Old-format labeled comments are cleaned up
+# ---------------------------------------------------------------------------
+run_test "Section consolidation: old-format labeled comments are deleted"
+
+event_payload="$(mktemp "${TMPDIR:-/tmp}/event-payload-XXXXXX.json")"
+echo '{"pull_request": {"number": 42}}' > "$event_payload"
+
+mock_bin="$(mktemp -d "${TMPDIR:-/tmp}/mock-bin-XXXXXX")"
+curl_log="${mock_bin}/curl.log"
+
+# Return both old-format labeled comment and no consolidated comment
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+echo "$@" >> "$(dirname "$0")/curl.log"
+if echo "$@" | grep -q "\-X DELETE\|\-X POST\|\-X PATCH"; then
+  echo '{}'
+else
+  echo '[{"id": 500, "body": "<!-- lcov-coverage-check:go -->\nold labeled report"}, {"id": 501, "body": "<!-- lcov-coverage-check:frontend -->\nold frontend report"}]'
 fi
 MOCKCURL
 chmod +x "${mock_bin}/curl"
@@ -49,276 +357,30 @@ else
   fail "expected exit code 0, got $exit_code"
 fi
 
-# The POST body should contain the warning about another check without coverage-label
-if grep -q 'coverage-label' "$curl_log" 2>/dev/null && grep -q 'without' "$curl_log" 2>/dev/null; then
-  pass "curl log contains collision warning about unlabeled check"
-else
-  fail "curl log missing collision warning about unlabeled check"
-fi
-
-# Since no existing labeled comment was found, it should POST (not PATCH)
+# Should POST a new consolidated comment (no existing consolidated comment)
 if grep -q '\-X POST' "$curl_log" 2>/dev/null; then
-  pass "curl used POST to create new labeled comment"
+  pass "curl used POST to create new consolidated comment"
 else
-  fail "curl should have used POST (no existing labeled comment)"
+  fail "curl should have used POST (no existing consolidated comment)"
 fi
 
-rm -f "$event_payload"
-rm -rf "$mock_bin"
-
-# ---------------------------------------------------------------------------
-# Test 49: Collision detection — unlabeled run finds labeled comment
-# ---------------------------------------------------------------------------
-run_test "Collision detection: unlabeled run finds labeled comment"
-
-event_payload="$(mktemp "${TMPDIR:-/tmp}/event-payload-XXXXXX.json")"
-echo '{"pull_request": {"number": 42}}' > "$event_payload"
-
-mock_bin="$(mktemp -d "${TMPDIR:-/tmp}/mock-bin-XXXXXX")"
-curl_log="${mock_bin}/curl.log"
-
-# Create comments.json: a labeled comment exists
-cat > "${mock_bin}/comments.json" <<'COMMENTS'
-[{"id": 200, "body": "<!-- lcov-coverage-check:go -->\nold labeled report"}]
-COMMENTS
-
-cat > "${mock_bin}/curl" <<'MOCKCURL'
-#!/usr/bin/env bash
-echo "$@" >> "$(dirname "$0")/curl.log"
-if echo "$@" | grep -q "\-X POST\|\-X PATCH"; then
-  echo '{}'
+# Should DELETE old-format labeled comments
+if grep -q '\-X DELETE.*comments/500' "$curl_log" 2>/dev/null; then
+  pass "old-format comment 500 was deleted"
 else
-  cat "$(dirname "$0")/comments.json"
-fi
-MOCKCURL
-chmod +x "${mock_bin}/curl"
-
-output="$(
-  PATH="${mock_bin}:${PATH}" \
-  GITHUB_EVENT_PATH="$event_payload" \
-  GITHUB_REPOSITORY="owner/repo" \
-  GITHUB_JOB="test-job" \
-  INPUT_LCOV_FILE="$FIXTURES_DIR/current.lcov.info" \
-  INPUT_LCOV_BASE="$FIXTURES_DIR/baseline.lcov.info" \
-  INPUT_BASE_REF="" \
-  INPUT_HEAD_REF="HEAD" \
-  INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_PATH="lib/" \
-  INPUT_CHANGED_FILE_NO_DECREASE="true" \
-  INPUT_IGNORE_PATTERNS="" \
-  INPUT_COVERAGE_LABEL="" \
-  INPUT_GITHUB_TOKEN="fake-token" \
-  bash "$CHECK_SCRIPT" 2>&1
-)" && exit_code=0 || exit_code=$?
-
-if [[ $exit_code -eq 0 ]]; then
-  pass "exit code is 0"
-else
-  fail "expected exit code 0, got $exit_code"
+  fail "old-format comment 500 should have been deleted"
 fi
 
-# The POST body should contain warning about other checks using coverage-label
-if grep -q 'coverage-label' "$curl_log" 2>/dev/null && grep -q 'collisions' "$curl_log" 2>/dev/null; then
-  pass "curl log contains collision warning about labeled checks"
+if grep -q '\-X DELETE.*comments/501' "$curl_log" 2>/dev/null; then
+  pass "old-format comment 501 was deleted"
 else
-  fail "curl log missing collision warning about labeled checks"
+  fail "old-format comment 501 should have been deleted"
 fi
 
-rm -f "$event_payload"
-rm -rf "$mock_bin"
-
-# ---------------------------------------------------------------------------
-# Test 50: Collision detection — unlabeled overwrites different source
-# ---------------------------------------------------------------------------
-run_test "Collision detection: unlabeled overwrites different source"
-
-event_payload="$(mktemp "${TMPDIR:-/tmp}/event-payload-XXXXXX.json")"
-echo '{"pull_request": {"number": 42}}' > "$event_payload"
-
-mock_bin="$(mktemp -d "${TMPDIR:-/tmp}/mock-bin-XXXXXX")"
-curl_log="${mock_bin}/curl.log"
-
-# Create comments.json: an unlabeled comment from a different source
-cat > "${mock_bin}/comments.json" <<COMMENTS
-[{"id": 300, "body": "<!-- lcov-coverage-check -->\n<!-- lcov-coverage-source:job-a:other-file.lcov -->\nold report from different source"}]
-COMMENTS
-
-cat > "${mock_bin}/curl" <<'MOCKCURL'
-#!/usr/bin/env bash
-echo "$@" >> "$(dirname "$0")/curl.log"
-if echo "$@" | grep -q "\-X POST\|\-X PATCH"; then
-  echo '{}'
+if echo "$output" | grep -q "Cleaned up old-format comment"; then
+  pass "output confirms old-format comment cleanup"
 else
-  cat "$(dirname "$0")/comments.json"
-fi
-MOCKCURL
-chmod +x "${mock_bin}/curl"
-
-output="$(
-  PATH="${mock_bin}:${PATH}" \
-  GITHUB_EVENT_PATH="$event_payload" \
-  GITHUB_REPOSITORY="owner/repo" \
-  GITHUB_JOB="job-b" \
-  INPUT_LCOV_FILE="$FIXTURES_DIR/current.lcov.info" \
-  INPUT_LCOV_BASE="$FIXTURES_DIR/baseline.lcov.info" \
-  INPUT_BASE_REF="" \
-  INPUT_HEAD_REF="HEAD" \
-  INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_PATH="lib/" \
-  INPUT_CHANGED_FILE_NO_DECREASE="true" \
-  INPUT_IGNORE_PATTERNS="" \
-  INPUT_COVERAGE_LABEL="" \
-  INPUT_GITHUB_TOKEN="fake-token" \
-  bash "$CHECK_SCRIPT" 2>&1
-)" && exit_code=0 || exit_code=$?
-
-if [[ $exit_code -eq 0 ]]; then
-  pass "exit code is 0"
-else
-  fail "expected exit code 0, got $exit_code"
-fi
-
-# The PATCH body should contain overwrite warning
-if grep -q 'overwritten' "$curl_log" 2>/dev/null; then
-  pass "curl log contains overwrite warning"
-else
-  fail "curl log missing overwrite warning"
-fi
-
-# Should use PATCH (updating existing comment)
-if grep -q '\-X PATCH' "$curl_log" 2>/dev/null; then
-  pass "curl used PATCH to update existing comment"
-else
-  fail "curl should have used PATCH"
-fi
-
-rm -f "$event_payload"
-rm -rf "$mock_bin"
-
-# ---------------------------------------------------------------------------
-# Test 51: No collision — same source updates itself
-# ---------------------------------------------------------------------------
-run_test "No collision: same source updates itself without warning"
-
-event_payload="$(mktemp "${TMPDIR:-/tmp}/event-payload-XXXXXX.json")"
-echo '{"pull_request": {"number": 42}}' > "$event_payload"
-
-mock_bin="$(mktemp -d "${TMPDIR:-/tmp}/mock-bin-XXXXXX")"
-curl_log="${mock_bin}/curl.log"
-
-# Create comments.json: an unlabeled comment from the same source
-cat > "${mock_bin}/comments.json" <<COMMENTS
-[{"id": 400, "body": "<!-- lcov-coverage-check -->\n<!-- lcov-coverage-source:test-job:${FIXTURES_DIR}/current.lcov.info -->\nold report from same source"}]
-COMMENTS
-
-cat > "${mock_bin}/curl" <<'MOCKCURL'
-#!/usr/bin/env bash
-echo "$@" >> "$(dirname "$0")/curl.log"
-if echo "$@" | grep -q "\-X POST\|\-X PATCH"; then
-  echo '{}'
-else
-  cat "$(dirname "$0")/comments.json"
-fi
-MOCKCURL
-chmod +x "${mock_bin}/curl"
-
-output="$(
-  PATH="${mock_bin}:${PATH}" \
-  GITHUB_EVENT_PATH="$event_payload" \
-  GITHUB_REPOSITORY="owner/repo" \
-  GITHUB_JOB="test-job" \
-  INPUT_LCOV_FILE="$FIXTURES_DIR/current.lcov.info" \
-  INPUT_LCOV_BASE="$FIXTURES_DIR/baseline.lcov.info" \
-  INPUT_BASE_REF="" \
-  INPUT_HEAD_REF="HEAD" \
-  INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_PATH="lib/" \
-  INPUT_CHANGED_FILE_NO_DECREASE="true" \
-  INPUT_IGNORE_PATTERNS="" \
-  INPUT_COVERAGE_LABEL="" \
-  INPUT_GITHUB_TOKEN="fake-token" \
-  bash "$CHECK_SCRIPT" 2>&1
-)" && exit_code=0 || exit_code=$?
-
-if [[ $exit_code -eq 0 ]]; then
-  pass "exit code is 0"
-else
-  fail "expected exit code 0, got $exit_code"
-fi
-
-# Should use PATCH (updating existing comment)
-if grep -q '\-X PATCH' "$curl_log" 2>/dev/null; then
-  pass "curl used PATCH to update existing comment"
-else
-  fail "curl should have used PATCH"
-fi
-
-# Should NOT contain any collision warning text
-if grep -q 'Warning' "$curl_log" 2>/dev/null; then
-  fail "curl log should NOT contain any warning (same source updating itself)"
-else
-  pass "no collision warning in curl log (same source)"
-fi
-
-rm -f "$event_payload"
-rm -rf "$mock_bin"
-
-# ---------------------------------------------------------------------------
-# Test 52: No false collision when ignore patterns rewrite LCOV path
-# ---------------------------------------------------------------------------
-run_test "No false collision: ignore patterns don't change source identity"
-
-event_payload="$(mktemp "${TMPDIR:-/tmp}/event-payload-XXXXXX.json")"
-echo '{"pull_request": {"number": 42}}' > "$event_payload"
-
-mock_bin="$(mktemp -d "${TMPDIR:-/tmp}/mock-bin-XXXXXX")"
-curl_log="${mock_bin}/curl.log"
-
-# Existing comment uses the original LCOV file path (not a temp filtered path)
-cat > "${mock_bin}/comments.json" <<COMMENTS
-[{"id": 500, "body": "<!-- lcov-coverage-check -->\n<!-- lcov-coverage-source:test-job:${FIXTURES_DIR}/current.lcov.info -->\nold report"}]
-COMMENTS
-
-cat > "${mock_bin}/curl" <<'MOCKCURL'
-#!/usr/bin/env bash
-echo "$@" >> "$(dirname "$0")/curl.log"
-if echo "$@" | grep -q "\-X POST\|\-X PATCH"; then
-  echo '{}'
-else
-  cat "$(dirname "$0")/comments.json"
-fi
-MOCKCURL
-chmod +x "${mock_bin}/curl"
-
-output="$(
-  PATH="${mock_bin}:${PATH}" \
-  GITHUB_EVENT_PATH="$event_payload" \
-  GITHUB_REPOSITORY="owner/repo" \
-  GITHUB_JOB="test-job" \
-  INPUT_LCOV_FILE="$FIXTURES_DIR/current.lcov.info" \
-  INPUT_LCOV_BASE="$FIXTURES_DIR/baseline.lcov.info" \
-  INPUT_BASE_REF="" \
-  INPUT_HEAD_REF="HEAD" \
-  INPUT_NEW_FILE_MINIMUM_COVERAGE="80" \
-  INPUT_PATH="lib/" \
-  INPUT_CHANGED_FILE_NO_DECREASE="true" \
-  INPUT_IGNORE_PATTERNS="*.g.dart" \
-  INPUT_COVERAGE_LABEL="" \
-  INPUT_GITHUB_TOKEN="fake-token" \
-  bash "$CHECK_SCRIPT" 2>&1
-)" && exit_code=0 || exit_code=$?
-
-if [[ $exit_code -eq 0 ]]; then
-  pass "exit code is 0"
-else
-  fail "expected exit code 0, got $exit_code"
-fi
-
-# Source tag should use original path, not temp filtered path — no false collision
-if grep -q 'Warning' "$curl_log" 2>/dev/null; then
-  fail "false collision warning triggered (source tag used filtered temp path instead of original)"
-else
-  pass "no false collision warning when ignore patterns are active"
+  fail "output missing old-format comment cleanup message"
 fi
 
 rm -f "$event_payload"

--- a/test/tests/12-validation.sh
+++ b/test/tests/12-validation.sh
@@ -122,14 +122,14 @@ output="$(
   bash "$CHECK_SCRIPT" 2>&1
 )" && exit_code=0 || exit_code=$?
 
-# The source tag should have double-dashes collapsed to single-dashes
-if grep -q 'lcov-coverage-source:ci-build-job:' "$curl_log" 2>/dev/null; then
-  pass "source tag has double-dashes sanitized to single-dashes"
+# The source tag (now inside a section) should have double-dashes collapsed to single-dashes
+if grep -q 'lcov-section-source:ci-build-job:' "$curl_log" 2>/dev/null; then
+  pass "section source tag has double-dashes sanitized to single-dashes"
 else
-  if grep -q 'lcov-coverage-source:ci--build--job:' "$curl_log" 2>/dev/null; then
-    fail "source tag still contains unsanitized double-dashes"
+  if grep -q 'lcov-section-source:ci--build--job:' "$curl_log" 2>/dev/null; then
+    fail "section source tag still contains unsanitized double-dashes"
   else
-    fail "source tag not found in curl log"
+    fail "section source tag not found in curl log"
   fi
 fi
 

--- a/test/tests/13-pagination.sh
+++ b/test/tests/13-pagination.sh
@@ -12,12 +12,7 @@ curl_log="${mock_bin}/curl.log"
 cat > "${mock_bin}/curl" <<'MOCKCURL'
 #!/usr/bin/env bash
 mock_dir="$(dirname "$0")"
-counter_file="${mock_dir}/curl_counter"
-if [[ ! -f "$counter_file" ]]; then echo 0 > "$counter_file"; fi
-count=$(cat "$counter_file")
-count=$((count + 1))
-echo "$count" > "$counter_file"
-echo "CALL $count: $@" >> "${mock_dir}/curl.log"
+echo "$@" >> "${mock_dir}/curl.log"
 
 # Parse -D argument for header dump file
 header_file=""
@@ -31,12 +26,15 @@ done
 
 if echo "$@" | grep -q "\-X POST\|\-X PATCH"; then
   echo '{}'
+elif echo "$@" | grep -q "issues/comments/88888" && ! echo "$@" | grep -q "\-D"; then
+  # Verify GET for specific comment (no -D flag = not a list request)
+  printf '{"body": "<!-- lcov-coverage-check -->\\n<!-- lcov-section:default -->\\nreport\\n<!-- lcov-section-end:default -->"}'
 elif echo "$@" | grep -q "page=2"; then
-  # Page 2: comment with the marker
+  # Page 2: comment with the marker (consolidated format with section)
   if [[ -n "$header_file" ]]; then
     printf 'HTTP/1.1 200 OK\r\n\r\n' > "$header_file"
   fi
-  echo '[{"id": 88888, "body": "<!-- lcov-coverage-check -->\nold report from page 2"}]'
+  echo '[{"id": 88888, "body": "<!-- lcov-coverage-check -->\n<!-- lcov-section:default -->\n<!-- lcov-section-source:old-job:old.lcov -->\nold report from page 2\n<!-- lcov-section-end:default -->"}]'
 else
   # Page 1: unrelated comment, with Link header indicating more pages
   if [[ -n "$header_file" ]]; then
@@ -106,12 +104,7 @@ curl_log="${mock_bin}/curl.log"
 cat > "${mock_bin}/curl" <<'MOCKCURL'
 #!/usr/bin/env bash
 mock_dir="$(dirname "$0")"
-counter_file="${mock_dir}/curl_counter"
-if [[ ! -f "$counter_file" ]]; then echo 0 > "$counter_file"; fi
-count=$(cat "$counter_file")
-count=$((count + 1))
-echo "$count" > "$counter_file"
-echo "CALL $count: $@" >> "${mock_dir}/curl.log"
+echo "$@" >> "${mock_dir}/curl.log"
 
 # Parse -D argument for header dump file
 header_file=""
@@ -175,9 +168,9 @@ rm -f "$event_payload"
 rm -rf "$mock_bin"
 
 # ---------------------------------------------------------------------------
-# Test 59: Collision detection works across paginated pages
+# Test 59: Labeled run adds section to existing consolidated comment across pages
 # ---------------------------------------------------------------------------
-run_test "Pagination: collision detection finds unlabeled comment across pages"
+run_test "Pagination: labeled run merges section into comment found on later page"
 
 event_payload="$(mktemp "${TMPDIR:-/tmp}/event-payload-XXXXXX.json")"
 echo '{"pull_request": {"number": 42}}' > "$event_payload"
@@ -188,12 +181,7 @@ curl_log="${mock_bin}/curl.log"
 cat > "${mock_bin}/curl" <<'MOCKCURL'
 #!/usr/bin/env bash
 mock_dir="$(dirname "$0")"
-counter_file="${mock_dir}/curl_counter"
-if [[ ! -f "$counter_file" ]]; then echo 0 > "$counter_file"; fi
-count=$(cat "$counter_file")
-count=$((count + 1))
-echo "$count" > "$counter_file"
-echo "CALL $count: $@" >> "${mock_dir}/curl.log"
+echo "$@" >> "${mock_dir}/curl.log"
 
 # Parse -D argument for header dump file
 header_file=""
@@ -207,6 +195,9 @@ done
 
 if echo "$@" | grep -q "\-X POST\|\-X PATCH"; then
   echo '{}'
+elif echo "$@" | grep -q "issues/comments/100" && ! echo "$@" | grep -q "\-D"; then
+  # Verify GET — return body with both sections
+  printf '{"body": "<!-- lcov-coverage-check -->\\n<!-- lcov-section:default -->\\nold report\\n<!-- lcov-section-end:default -->\\n<!-- lcov-section:go -->\\ngo report\\n<!-- lcov-section-end:go -->"}'
 elif echo "$@" | grep -q "page=2"; then
   # Page 2: empty
   if [[ -n "$header_file" ]]; then
@@ -214,11 +205,11 @@ elif echo "$@" | grep -q "page=2"; then
   fi
   echo '[]'
 else
-  # Page 1: unlabeled coverage comment, with Link header
+  # Page 1: consolidated comment with existing default section, plus Link header
   if [[ -n "$header_file" ]]; then
     printf 'HTTP/1.1 200 OK\r\nLink: <https://api.github.com/next>; rel="next"\r\n\r\n' > "$header_file"
   fi
-  echo '[{"id": 100, "body": "<!-- lcov-coverage-check -->\nold unlabeled report"}]'
+  echo '[{"id": 100, "body": "<!-- lcov-coverage-check -->\n<!-- lcov-section:default -->\n<!-- lcov-section-source:job-a:file.lcov -->\nold report\n<!-- lcov-section-end:default -->"}]'
 fi
 MOCKCURL
 chmod +x "${mock_bin}/curl"
@@ -227,7 +218,7 @@ output="$(
   PATH="${mock_bin}:${PATH}" \
   GITHUB_EVENT_PATH="$event_payload" \
   GITHUB_REPOSITORY="owner/repo" \
-  GITHUB_JOB="test-job" \
+  GITHUB_JOB="go-job" \
   INPUT_LCOV_FILE="$FIXTURES_DIR/current.lcov.info" \
   INPUT_LCOV_BASE="$FIXTURES_DIR/baseline.lcov.info" \
   INPUT_BASE_REF="" \
@@ -247,18 +238,17 @@ else
   fail "expected exit code 0, got $exit_code"
 fi
 
-# Collision warning should be present (unlabeled comment found while running labeled check)
-if grep -q 'coverage-label' "$curl_log" 2>/dev/null && grep -q 'without' "$curl_log" 2>/dev/null; then
-  pass "collision warning about unlabeled check detected across pages"
+# Should PATCH the existing consolidated comment with both sections
+if grep -q '\-X PATCH' "$curl_log" 2>/dev/null; then
+  pass "curl used PATCH to update existing consolidated comment"
 else
-  fail "curl log missing collision warning about unlabeled check"
+  fail "curl should have used PATCH"
 fi
 
-# Should POST (not PATCH) since no labeled comment exists
-if grep -q '\-X POST' "$curl_log" 2>/dev/null; then
-  pass "curl used POST to create new labeled comment"
+if grep -q 'lcov-section:default' "$curl_log" 2>/dev/null && grep -q 'lcov-section:go' "$curl_log" 2>/dev/null; then
+  pass "PATCH body contains both 'default' and 'go' sections"
 else
-  fail "curl should have used POST (no existing labeled comment)"
+  fail "PATCH body should contain both existing 'default' and new 'go' sections"
 fi
 
 rm -f "$event_payload"


### PR DESCRIPTION
## Summary

- All coverage labels now share **one consolidated PR comment** instead of posting separate comments per label
- Each label occupies its own section (`<\!-- lcov-section:KEY -->`) within the comment, independently updated via read-modify-write with retry (3 attempts) for concurrent update resilience
- New `scripts/lib/comment.sh` library handles section parsing, building, and merging (with alphabetical sorting, `default` first)
- Old-format per-label comments (`<\!-- lcov-coverage-check:LABEL -->`) are automatically cleaned up on migration
- Collision detection system removed — no longer needed since all labels share one comment
- Uses `jq --argjson` for safe ID interpolation and `printf '%s'` for precise JSON encoding

## Test plan

- [x] All 62 tests pass (169 assertions, 0 failures) via `./test/run-tests.sh`
- [x] New section added alongside existing section preserves both (test 48)
- [x] Existing section replaced with updated content (test 49)
- [x] Unlabeled runs use `default` section key (test 50)
- [x] Old-format comment without sections gets migrated (test 51)
- [x] Sections sorted: `default` first, then alphabetical (test 52)
- [x] Old-format labeled comments are deleted during migration (test 53)
- [x] Pagination finds and merges into consolidated comment across pages (test 60)
- [x] Retry loop warns on exhaustion rather than silently claiming success