### PR TITLE
fix: page through default-branch runs to find baseline artifact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ A reusable composite GitHub Action (pure bash, no Node.js) that parses LCOV cove
 ## Architecture
 
 - **`scripts/check-coverage.sh`** — Main entry point. Parses LCOV files, runs three checks (overall ratchet, new-file threshold, changed-file ratchet), generates markdown summary, and posts PR comments.
-- **`scripts/retrieve-baseline.sh`** — Retrieves baseline LCOV artifact from the latest successful default-branch workflow run. Gracefully falls back to summary-only mode on any error.
+- **`scripts/retrieve-baseline.sh`** — Retrieves the baseline LCOV artifact, paging back (newest first) through recent successful default-branch runs of the same workflow to find the first that still holds a non-expired `lcov-baseline[-<label>]` artifact. Gracefully falls back to summary-only mode if none is found or on any error.
 - **`scripts/lib/`** — Shared library files sourced by the main scripts:
   - `common.sh` — `write_output()`, `append_summary()`
   - `lcov.sh` — LCOV parsing (`parse_lcov_overall`, `parse_lcov_per_file`), numeric helpers (`coverage_pct`, `compare_floats`, `format_pct`), extension extraction

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Labels are normalized to lowercase alphanumeric characters and hyphens.
 When `github-token` is provided, the action automatically manages baseline coverage artifacts:
 
 1. **On pushes to the default branch** (e.g., `main`): the current LCOV file is uploaded as an `lcov-baseline` artifact, overwriting any previous baseline.
-2. **On pull requests**: the action retrieves the `lcov-baseline` artifact from the latest successful default-branch run of the same workflow. It also extracts `base.sha` and `head.sha` from the PR event payload for `git diff` operations.
+2. **On pull requests**: the action retrieves the `lcov-baseline` artifact from the same workflow's default-branch runs. Because a successful run does not always produce a baseline (the coverage job may be skipped by path filters or matrix), it pages back through recent successful runs (newest first) and uses the first that still holds a non-expired `lcov-baseline` artifact. It also extracts `base.sha` and `head.sha` from the PR event payload for `git diff` operations.
 3. **On pull requests**: the current LCOV file is also uploaded as an `lcov-coverage` artifact.
 
 When `coverage-label` is set, artifact names are suffixed (e.g., `lcov-baseline-go`, `lcov-coverage-frontend`). Each label tracks its own independent baseline.
@@ -211,7 +211,7 @@ For new/modified file detection, the action needs access to both the base and he
 
 - **Empty or missing LCOV files**: Treated as 0% coverage (not an error)
 - **First run (no baseline)**: Runs in summary-only mode. Baseline stored for next PR.
-- **Expired artifact**: Filtered by `expired == false`. Graceful fallback to summary-only.
+- **Expired artifact**: Filtered by `expired == false`. Retrieval pages back to an earlier run with a valid baseline; falls back to summary-only only if none is found.
 - **Fork PRs**: Token may lack `actions: read`. ERR trap handles graceful fallback.
 - **New file not in LCOV data**: Treated as 0% coverage, fails if below threshold
 - **New file with `LF:0`**: No instrumentable lines, passes automatically

--- a/scripts/retrieve-baseline.sh
+++ b/scripts/retrieve-baseline.sh
@@ -82,20 +82,7 @@ if [[ -z "$default_branch" || "$default_branch" == "null" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 3. Find latest successful run on default branch
-# ---------------------------------------------------------------------------
-run_id="$(curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
-  "${API_BASE}/repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_id}/runs?branch=${default_branch}&status=success&per_page=1" \
-  | jq -r '.workflow_runs[0].id // empty')"
-
-if [[ -z "$run_id" ]]; then
-  echo "::notice::No successful runs found on ${default_branch} — running in summary-only mode"
-  write_output "downloaded" "false"
-  exit 0
-fi
-
-# ---------------------------------------------------------------------------
-# 4. Find lcov-baseline artifact (not expired)
+# 3. Determine the baseline artifact name (label-aware)
 # ---------------------------------------------------------------------------
 if [[ -n "$INPUT_COVERAGE_LABEL" ]]; then
   ARTIFACT_NAME="lcov-baseline-${INPUT_COVERAGE_LABEL}"
@@ -103,13 +90,69 @@ else
   ARTIFACT_NAME="lcov-baseline"
 fi
 
-artifact_url="$(curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
-  "${API_BASE}/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts" \
-  | jq -r --arg name "${ARTIFACT_NAME}" '.artifacts[] | select(.name == $name and .expired == false) | .archive_download_url' \
-  | head -1)"
+# ---------------------------------------------------------------------------
+# 4. Find the most recent successful default-branch run that still holds a
+#    non-expired baseline artifact.
+#
+#    A successful run does not guarantee a baseline: the coverage job is often
+#    conditional (path filters, matrix skips, flaky reruns), so the newest run
+#    can complete without producing one while an older run still has a valid
+#    baseline. Page back through recent runs and use the first match, only
+#    falling back to summary-only mode when none of the inspected runs has one.
+#    Pagination mirrors the Link-header idiom in check-coverage.sh.
+# ---------------------------------------------------------------------------
+artifact_url=""
+run_id=""
+runs_page=1
+while true; do
+  runs_header_file="$(mktemp "${TMPDIR:-/tmp}/lcov-run-headers-XXXXXX")"
+  runs_response="$(curl -s -D "$runs_header_file" -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
+    "${API_BASE}/repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_id}/runs?branch=${default_branch}&status=success&per_page=100&page=${runs_page}" \
+    || true)"
+
+  # Stop if the response is not the expected shape (API error, rate limit, etc.)
+  if ! echo "$runs_response" | jq -e '.workflow_runs | type == "array"' > /dev/null 2>&1; then
+    rm -f "$runs_header_file"
+    break
+  fi
+
+  # Inspect each run on this page (newest first) for a non-expired baseline artifact
+  run_ids="$(echo "$runs_response" | jq -r '.workflow_runs[].id // empty')"
+  while IFS= read -r candidate_run_id; do
+    if [[ -z "$candidate_run_id" ]]; then
+      continue
+    fi
+    # A transient failure (or jq error on a malformed/non-array response) for one
+    # run should not abort the whole search — skip it and keep paging.
+    candidate_url="$(curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
+      "${API_BASE}/repos/${GITHUB_REPOSITORY}/actions/runs/${candidate_run_id}/artifacts" \
+      | jq -r --arg name "${ARTIFACT_NAME}" '.artifacts[] | select(.name == $name and .expired == false) | .archive_download_url' \
+      | head -1 || true)"
+    if [[ -n "$candidate_url" ]]; then
+      artifact_url="$candidate_url"
+      run_id="$candidate_run_id"
+      break
+    fi
+  done <<< "$run_ids"
+
+  # Advance to the next page only if one exists and we haven't found an artifact yet
+  has_next="$(grep -i '^link:' "$runs_header_file" | grep -o 'rel="next"' || true)"
+  rm -f "$runs_header_file"
+
+  if [[ -n "$artifact_url" ]]; then
+    break
+  fi
+  if [[ -z "$has_next" ]]; then
+    break
+  fi
+  runs_page=$((runs_page + 1))
+  if [[ $runs_page -gt 50 ]]; then
+    break
+  fi
+done
 
 if [[ -z "$artifact_url" ]]; then
-  echo "::notice::No ${ARTIFACT_NAME} artifact found in run ${run_id} — running in summary-only mode"
+  echo "::notice::No ${ARTIFACT_NAME} artifact found in recent successful ${default_branch} runs — running in summary-only mode"
   write_output "downloaded" "false"
   exit 0
 fi
@@ -117,7 +160,7 @@ fi
 # ---------------------------------------------------------------------------
 # 5. Download and extract artifact
 # ---------------------------------------------------------------------------
-tmpdir="$(mktemp -d)"
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-artifact-XXXXXX")"
 curl -s -L -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
   -o "${tmpdir}/artifact.zip" "$artifact_url"
 

--- a/test/tests/05-baseline-retrieval.sh
+++ b/test/tests/05-baseline-retrieval.sh
@@ -415,3 +415,264 @@ else
 fi
 
 rm -rf "$tmpdir"
+
+# ---------------------------------------------------------------------------
+# Test 21: Baseline retrieval — older run on same page when newest lacks artifact
+# ---------------------------------------------------------------------------
+run_test "Baseline retrieval: pages to older run when newest lacks artifact"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-test-XXXXXX")"
+
+# Create a baseline LCOV file and zip it
+mkdir -p "${tmpdir}/artifact-content"
+cp "$FIXTURES_DIR/baseline.lcov.info" "${tmpdir}/artifact-content/lcov.info"
+(cd "${tmpdir}/artifact-content" && zip -q "${tmpdir}/test-artifact.zip" lcov.info)
+
+mock_bin="${tmpdir}/mock-bin"
+mkdir -p "$mock_bin"
+cp "${tmpdir}/test-artifact.zip" "${mock_bin}/test-artifact.zip"
+# URL-routed mock: newest run (67890) has no artifact, older run (67891) does
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+mock_dir="$(dirname "$0")"
+echo "$@" >> "${mock_dir}/curl.log"
+
+args=("$@")
+output_file=""
+header_file=""
+for ((i=0; i<${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    -o) output_file="${args[$((i+1))]}" ;;
+    -D) header_file="${args[$((i+1))]}" ;;
+  esac
+done
+url="${args[$((${#args[@]}-1))]}"
+
+if [[ -n "$output_file" ]]; then
+  cp "${mock_dir}/test-artifact.zip" "$output_file"
+elif [[ "$url" == *"/actions/workflows/12345/runs"* ]]; then
+  [[ -n "$header_file" ]] && printf 'HTTP/1.1 200 OK\r\n\r\n' > "$header_file"
+  echo '{"workflow_runs": [{"id": 67890}, {"id": 67891}]}'
+elif [[ "$url" == *"/actions/runs/67890/artifacts"* ]]; then
+  echo '{"artifacts": []}'
+elif [[ "$url" == *"/actions/runs/67891/artifacts"* ]]; then
+  echo '{"artifacts": [{"name": "lcov-baseline", "expired": false, "archive_download_url": "https://example.com/artifact.zip"}]}'
+elif [[ "$url" == *"/actions/runs/11111"* ]]; then
+  printf '%s\n%s' '{"workflow_id": 12345}' '200'
+elif [[ "$url" == *"/repos/owner/repo" ]]; then
+  echo '{"default_branch": "main"}'
+fi
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
+github_output="${tmpdir}/github_output"
+: > "$github_output"
+
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_OUTPUT="$github_output" \
+  GITHUB_REPOSITORY="owner/repo" \
+  GITHUB_RUN_ID="11111" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$RETRIEVE_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+if grep -q "downloaded=true" "$github_output"; then
+  pass "output contains downloaded=true"
+else
+  fail "output missing downloaded=true"
+fi
+
+if grep -q "baseline-path=" "$github_output"; then
+  baseline_path="$(grep "baseline-path=" "$github_output" | cut -d= -f2-)"
+  if [[ -f "$baseline_path" ]]; then
+    pass "baseline file exists at output path"
+  else
+    fail "baseline file does not exist at output path"
+  fi
+else
+  fail "output missing baseline-path"
+fi
+
+if echo "$output" | grep -q "run 67891"; then
+  pass "selected the older run (67891) that holds the artifact"
+else
+  fail "did not select the older run holding the artifact"
+fi
+
+rm -rf "$tmpdir"
+
+# ---------------------------------------------------------------------------
+# Test 22: Baseline retrieval — pages to second API page to find artifact
+# ---------------------------------------------------------------------------
+run_test "Baseline retrieval: pages to second API page to find artifact"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-test-XXXXXX")"
+
+mkdir -p "${tmpdir}/artifact-content"
+cp "$FIXTURES_DIR/baseline.lcov.info" "${tmpdir}/artifact-content/lcov.info"
+(cd "${tmpdir}/artifact-content" && zip -q "${tmpdir}/test-artifact.zip" lcov.info)
+
+mock_bin="${tmpdir}/mock-bin"
+mkdir -p "$mock_bin"
+curl_log="${mock_bin}/curl.log"
+cp "${tmpdir}/test-artifact.zip" "${mock_bin}/test-artifact.zip"
+# Page 1 run (67890) has no artifact and a "next" link; page 2 run (67999) has it
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+mock_dir="$(dirname "$0")"
+echo "$@" >> "${mock_dir}/curl.log"
+
+args=("$@")
+output_file=""
+header_file=""
+for ((i=0; i<${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    -o) output_file="${args[$((i+1))]}" ;;
+    -D) header_file="${args[$((i+1))]}" ;;
+  esac
+done
+url="${args[$((${#args[@]}-1))]}"
+
+if [[ -n "$output_file" ]]; then
+  cp "${mock_dir}/test-artifact.zip" "$output_file"
+elif [[ "$url" == *"/actions/workflows/12345/runs"* ]]; then
+  if [[ "$url" == *"page=2"* ]]; then
+    [[ -n "$header_file" ]] && printf 'HTTP/1.1 200 OK\r\n\r\n' > "$header_file"
+    echo '{"workflow_runs": [{"id": 67999}]}'
+  else
+    [[ -n "$header_file" ]] && printf 'HTTP/1.1 200 OK\r\nLink: <https://api.github.com/x?page=2>; rel="next"\r\n\r\n' > "$header_file"
+    echo '{"workflow_runs": [{"id": 67890}]}'
+  fi
+elif [[ "$url" == *"/actions/runs/67890/artifacts"* ]]; then
+  echo '{"artifacts": []}'
+elif [[ "$url" == *"/actions/runs/67999/artifacts"* ]]; then
+  echo '{"artifacts": [{"name": "lcov-baseline", "expired": false, "archive_download_url": "https://example.com/artifact.zip"}]}'
+elif [[ "$url" == *"/actions/runs/11111"* ]]; then
+  printf '%s\n%s' '{"workflow_id": 12345}' '200'
+elif [[ "$url" == *"/repos/owner/repo" ]]; then
+  echo '{"default_branch": "main"}'
+fi
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
+github_output="${tmpdir}/github_output"
+: > "$github_output"
+
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_OUTPUT="$github_output" \
+  GITHUB_REPOSITORY="owner/repo" \
+  GITHUB_RUN_ID="11111" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$RETRIEVE_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+if grep -q "downloaded=true" "$github_output"; then
+  pass "output contains downloaded=true"
+else
+  fail "output missing downloaded=true"
+fi
+
+if grep -q "page=2" "$curl_log" 2>/dev/null; then
+  pass "curl followed the Link header to fetch page 2"
+else
+  fail "curl did not fetch page 2"
+fi
+
+if echo "$output" | grep -q "run 67999"; then
+  pass "selected the run (67999) from the second page"
+else
+  fail "did not select the run from the second page"
+fi
+
+rm -rf "$tmpdir"
+
+# ---------------------------------------------------------------------------
+# Test 23: Baseline retrieval — exhausts page cap then falls back
+# ---------------------------------------------------------------------------
+run_test "Baseline retrieval: exhausts page cap then falls back to summary-only"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-test-XXXXXX")"
+
+mock_bin="${tmpdir}/mock-bin"
+mkdir -p "$mock_bin"
+curl_log="${mock_bin}/curl.log"
+# Every page returns a run with no artifact and always advertises a next page,
+# so retrieval must stop at the 50-page cap and fall back to summary-only.
+cat > "${mock_bin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+mock_dir="$(dirname "$0")"
+echo "$@" >> "${mock_dir}/curl.log"
+
+args=("$@")
+header_file=""
+for ((i=0; i<${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    -D) header_file="${args[$((i+1))]}" ;;
+  esac
+done
+url="${args[$((${#args[@]}-1))]}"
+
+if [[ "$url" == *"/actions/workflows/12345/runs"* ]]; then
+  [[ -n "$header_file" ]] && printf 'HTTP/1.1 200 OK\r\nLink: <https://api.github.com/x>; rel="next"\r\n\r\n' > "$header_file"
+  echo '{"workflow_runs": [{"id": 67890}]}'
+elif [[ "$url" == *"/actions/runs/67890/artifacts"* ]]; then
+  echo '{"artifacts": []}'
+elif [[ "$url" == *"/actions/runs/11111"* ]]; then
+  printf '%s\n%s' '{"workflow_id": 12345}' '200'
+elif [[ "$url" == *"/repos/owner/repo" ]]; then
+  echo '{"default_branch": "main"}'
+fi
+MOCKCURL
+chmod +x "${mock_bin}/curl"
+
+github_output="${tmpdir}/github_output"
+: > "$github_output"
+
+output="$(
+  PATH="${mock_bin}:${PATH}" \
+  GITHUB_OUTPUT="$github_output" \
+  GITHUB_REPOSITORY="owner/repo" \
+  GITHUB_RUN_ID="11111" \
+  INPUT_GITHUB_TOKEN="fake-token" \
+  bash "$RETRIEVE_SCRIPT" 2>&1
+)" && exit_code=0 || exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  pass "exit code is 0 (graceful fallback)"
+else
+  fail "expected exit code 0, got $exit_code"
+fi
+
+if grep -q "downloaded=false" "$github_output"; then
+  pass "output contains downloaded=false"
+else
+  fail "output missing downloaded=false"
+fi
+
+if grep -q "page=50" "$curl_log" 2>/dev/null; then
+  pass "paged up to the 50-page cap"
+else
+  fail "did not page up to the cap"
+fi
+
+if ! grep -q "page=51" "$curl_log" 2>/dev/null; then
+  pass "stopped at the 50-page cap (did not fetch page 51)"
+else
+  fail "exceeded the 50-page cap"
+fi
+
+rm -rf "$tmpdir"

--- a/test/tests/14-temp-cleanup.sh
+++ b/test/tests/14-temp-cleanup.sh
@@ -4,7 +4,7 @@
 run_test "Temp cleanup: filtered LCOV temp files removed on success"
 
 # Use an isolated TMPDIR so we can verify cleanup
-test_tmpdir="$(mktemp -d)"
+test_tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-cleanup-XXXXXX")"
 
 output="$(
   TMPDIR="$test_tmpdir" \
@@ -41,7 +41,7 @@ rm -rf "$test_tmpdir"
 run_test "Temp cleanup: filtered LCOV temp files removed on failure"
 
 # Use an isolated TMPDIR so we can verify cleanup
-test_tmpdir="$(mktemp -d)"
+test_tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lcov-cleanup-XXXXXX")"
 
 # decreased.lcov.info (50%) vs baseline.lcov.info (62.5%) — overall ratchet fails.
 # Ignore patterns are set so filter_lcov_file creates temp files for both.


### PR DESCRIPTION
## Problem

`retrieve-baseline.sh` found the baseline by querying the workflow's default-branch runs with `per_page=1` and inspecting only that **single most recent** successful run for the `lcov-baseline[-<label>]` artifact.

But a successful run does not guarantee a baseline artifact — the coverage job is often conditional (path filters, matrix skips, flaky reruns), so the latest run can legitimately complete without producing one while an **older** default-branch run still holds a valid baseline. Because retrieval never looked past the newest run, it fell back to summary-only mode even though a usable baseline existed.

Summary-only mode silently disables the action's purpose: ratcheting isn't enforced (`passed=true` hardcoded) and no PR comparison comment is posted. Coverage could regress behind a green check, intermittently, depending only on what the most recent default-branch commit happened to touch.

## Fix

Retrieval now selects the most recent successful default-branch run that **actually contains** a non-expired baseline artifact:

- Page through recent successful default-branch runs (newest first), checking each run's artifacts, and use the first match.
- Only fall back to summary-only mode when **none** of the inspected runs has one.
- Pagination follows the `Link: rel="next"` header with `per_page=100` and a 50-page cap, mirroring the existing comment-pagination idiom in `check-coverage.sh`. No new constants or action inputs.
- The existing `expired == false` filter and `coverage-label` → artifact-name mapping are preserved.

### Additional hardening / cleanup
- The per-run artifact query is guarded so a transient failure (or a malformed/non-array response) for one run skips that run and keeps paging, instead of aborting the whole search via the `ERR` trap.
- Run-id parsing guarded with `// empty`.
- `mktemp` calls use the `${TMPDIR:-/tmp}/…XXXXXX` template form, matching the rest of the codebase (portable; bare `mktemp -d` on macOS ignores `$TMPDIR`). This also fixes the pre-existing bare calls in `14-temp-cleanup.sh`.

## Tests

Added to `test/tests/05-baseline-retrieval.sh`:
- **Older run on the same page** is used when the newest lacks the artifact.
- **Pages to the second API page** (Link-following) to find the artifact.
- **Exhausts the 50-page cap** then falls back to summary-only.

Full suite: **65 tests, 181 assertions, 0 failures.** Existing baseline tests (15–20) still pass unchanged.

## Docs
- `README.md` — updated "Automatic Baseline Management" and the expired-artifact edge case.
- `CLAUDE.md` — updated the `retrieve-baseline.sh` description.